### PR TITLE
Renamed: Fast Settings to Quick Settings

### DIFF
--- a/static/placeholders/default.yml
+++ b/static/placeholders/default.yml
@@ -62,4 +62,4 @@ right:
 
   - type: settings
     template: icon.LuSettings2
-    tooltip: '"Fast Settings"'
+    tooltip: '"Quick Settings"'


### PR DESCRIPTION
- Renamed the Fast Settings hover title to Quick Settings for simplified messaging.