### PR TITLE
Notification preview item(s) for newly come notifications

### DIFF
--- a/lib/src/utils/hooks.ts
+++ b/lib/src/utils/hooks.ts
@@ -25,3 +25,17 @@ export function useInterval(cb: () => void, ms: number, deps: any[] = []) {
     return clearLastInterval;
   }, [ms, ...deps]);
 }
+
+export function useTimeout(cb: () => void, ms: number, deps: any[] = []) {
+  const ref = useRef<NodeJS.Timeout | null>(null);
+  const clearLastTimeout = () => {
+    if (ref.current) {
+      clearTimeout(ref.current);
+    }
+  };
+  useEffect(() => {
+    clearLastTimeout();
+    ref.current = setTimeout(cb, ms);
+    return clearLastTimeout;
+  }, [ms, ...deps]);
+}

--- a/src/apps/toolbar/modules/Notifications/infra/ArrivalPreview.tsx
+++ b/src/apps/toolbar/modules/Notifications/infra/ArrivalPreview.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable @stylistic/indent */
+import { invoke } from '@tauri-apps/api/core';
+import { Button } from 'antd';
+import { AnimatePresence, motion } from 'framer-motion';
+import moment from 'moment';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { SeelenCommand, useTimeout } from 'seelen-core';
+
+import { BackgroundByLayersV2 } from '../../../../seelenweg/components/BackgroundByLayers/infra';
+
+import { Selectors } from '../../shared/store/app';
+
+import { Icon } from '../../../../shared/components/Icon';
+
+// Difference between Windows epoch (1601) and Unix epoch (1970) in milliseconds
+const EPOCH_DIFF_MILLISECONDS = 11644473600000n;
+const notificationArrivalViewTime = 10 * 1000;
+
+function WindowsDateFileTimeToDate(fileTime: bigint) {
+  return new Date(Number(fileTime / 10000n - EPOCH_DIFF_MILLISECONDS));
+}
+
+export function ArrivalPreview() {
+  const notifications = useSelector(Selectors.notifications);
+  const [ currentNotificationPreviewSet, setCurrentNotificationPreviewSet ] = useState(false);
+
+  useTimeout(() => {
+    setCurrentNotificationPreviewSet(notifications.filter((notification) => {
+      const arrivalDate = WindowsDateFileTimeToDate(BigInt(notification.date));
+
+      return moment(Date.now()).diff(arrivalDate, 'seconds') < 10;
+    }));
+  }, notificationArrivalViewTime, [currentNotificationPreviewSet]);
+
+  useEffect(() => {
+    setCurrentNotificationPreviewSet(notifications.filter((notification) => {
+      const arrivalDate = WindowsDateFileTimeToDate(BigInt(notification.date));
+
+      return moment(Date.now()).diff(arrivalDate, 'seconds') < 10;
+    }));
+  }, [notifications]);
+
+  return (
+    <BackgroundByLayersV2 className="notification-arrival">
+      <AnimatePresence>
+        { currentNotificationPreviewSet &&
+            currentNotificationPreviewSet.map((notification) => {
+              return (
+                <motion.div
+                  className="notification"
+                  key={notification.id}
+                  animate={{ x: '0%', opacity: 1 }}
+                  exit={{ x: '100%', opacity: 0 }}
+                  initial={{ x: '100%', opacity: 1 }}
+                  transition={{ duration: 0.4 }}
+                >
+                  <div className="notification-header">
+                    <div className="notification-header-info">
+                      <Icon iconName="TbNotification" />
+                      <div>{notification.app_name}</div>
+                      <span>-</span>
+                      <div>
+                        {moment(WindowsDateFileTimeToDate(BigInt(notification.date))).fromNow()}
+                      </div>
+                    </div>
+                    <Button
+                      size="small"
+                      type="text"
+                      onClick={() => {
+                        invoke(SeelenCommand.NotificationsClose, { id: notification.id }).catch(console.error);
+                      } }
+                    >
+                      <Icon iconName="IoClose" />
+                    </Button>
+                  </div>
+                  <div className="notification-body">
+                    <h2 className="notification-body-title">{notification.body[0]}</h2>
+                    {notification.body.slice(1).map((body, idx) => (
+                      <p key={idx}>{body}</p>
+                    ))}
+                  </div>
+                </motion.div>
+              );
+            })}
+      </AnimatePresence>
+    </BackgroundByLayersV2>
+  );
+}

--- a/src/apps/toolbar/modules/Notifications/infra/Module.tsx
+++ b/src/apps/toolbar/modules/Notifications/infra/Module.tsx
@@ -1,9 +1,8 @@
 import { emit } from '@tauri-apps/api/event';
 import { Popover } from 'antd';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useWindowFocusChange } from 'seelen-core';
-import { NotificationsTM } from 'seelen-core';
+import { NotificationsTM, useWindowFocusChange } from 'seelen-core';
 
 import { Item } from '../../item/infra/infra';
 
@@ -11,6 +10,7 @@ import { Selectors } from '../../shared/store/app';
 
 import { RootState } from '../../shared/store/domain';
 
+import { ArrivalPreview } from './ArrivalPreview';
 import { Notifications } from './Notifications';
 
 interface Props {
@@ -32,14 +32,23 @@ export function NotificationsModule({ module }: Props) {
   }, []);
 
   return (
-    <Popover
-      open={openPreview}
-      trigger="click"
-      onOpenChange={setOpenPreview}
-      arrow={false}
-      content={<Notifications />}
-    >
-      <Item extraVars={{ count }} module={module} />
-    </Popover>
+    <React.Fragment>
+      <Popover
+        open={openPreview}
+        trigger="click"
+        onOpenChange={setOpenPreview}
+        arrow={false}
+        content={<Notifications />}
+      >
+        <Item extraVars={{ count }} module={module} />
+      </Popover>
+      <Popover
+        open={!openPreview}
+        arrow={false}
+        content={<ArrivalPreview />}
+      >
+
+      </Popover>
+    </React.Fragment>
   );
 }

--- a/static/themes/default/theme.toolbar.css
+++ b/static/themes/default/theme.toolbar.css
@@ -386,6 +386,28 @@
   }
 }
 
+@keyframes text-highlight {
+  0% { color: var(--color-gray-300); }
+  66% { color: var(--config-accent-color); }
+  100% { color: var(--color-gray-300); }
+}
+
+.notification-arrival {
+  margin: var(--popups-margin);
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: calc(100vh - var(--config-height) - (var(--popups-margin) * 2));
+  padding: 0 2px;  
+  overflow-y: hidden;
+  overflow-x: hidden;
+
+  & .notification-header-info {
+    animation: text-highlight 5s ease-in-out infinite;
+  }
+}
+
 .notifications-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Currently it is not configurable.

Cunfiguration options: 
- Do it or not.
- Show time before disappearing

Current work: 
New notification will be displayed on a bubble, like the notifications, but it is visible, if the notifications themselves are not. 
![image](https://github.com/user-attachments/assets/0ab2aa6d-7d07-4613-9d00-d64d3bb9b62a)

(root theme, which made a toolbar look a bit different, is not target of the commit it just visible on the screenshot.)

The new notification will be visible only for 10 seconds after that they are swiped out. 

Features like in notification: you can close it on preview. 

Modules are not changed entirely ^^ coparer got crazy, only new popup came in with a React.Fragment.

Solves issue: https://github.com/eythaann/Seelen-UI/issues/55
Although i think this is a feature request not a bug...