### PR TITLE
Add new option HideMode.NeverWithoutPlaceholder

### DIFF
--- a/documentation/schemas/settings.schema.json
+++ b/documentation/schemas/settings.schema.json
@@ -1169,6 +1169,13 @@
           ]
         },
         {
+          "description": "Never hide, but do not make a placeholder for it",
+          "type": "string",
+          "enum": [
+            "Never without placeholder"
+          ]
+        },
+        {
           "description": "auto-hide always on",
           "type": "string",
           "enum": [

--- a/lib/src/state/settings.rs
+++ b/lib/src/state/settings.rs
@@ -54,6 +54,9 @@ pub enum SeelenWegMode {
 pub enum HideMode {
     /// never hide
     Never,
+    /// Never hide, but do not make a placeholder for it
+    #[serde(rename = "Never without placeholder")]
+    NeverWithoutPlaceholder,
     /// auto-hide always on
     Always,
     /// auto-hide only if is overlaped by the focused window

--- a/lib/src/state/settings.ts
+++ b/lib/src/state/settings.ts
@@ -14,6 +14,7 @@ export enum SeelenWegMode {
 
 export enum HideMode {
   Never = 'Never',
+  NeverWithoutPlaceholder = 'Never without placeholder',
   Always = 'Always',
   OnOverlap = 'On-Overlap',
 }

--- a/src/apps/seelenweg/modules/bar/index.tsx
+++ b/src/apps/seelenweg/modules/bar/index.tsx
@@ -42,6 +42,7 @@ function shouldBeHidden(hideMode: HideMode, isActive: boolean, isOverlaped: bool
     case HideMode.Always:
       shouldBeHidden = !isActive;
       break;
+    case HideMode.NeverWithoutPlaceholder:
     case HideMode.Never:
       shouldBeHidden = false;
       break;

--- a/src/apps/toolbar/modules/main/infra.tsx
+++ b/src/apps/toolbar/modules/main/infra.tsx
@@ -92,7 +92,7 @@ export function ToolBar({ structure }: Props) {
   );
 
   const shouldBeHidden =
-    !isAppFocused && hideMode !== HideMode.Never && (isOverlaped || hideMode === HideMode.Always);
+    !isAppFocused && hideMode !== HideMode.Never && ((isOverlaped && hideMode === HideMode.OnOverlap) || hideMode == HideMode.Always);
 
   return (
     <Reorder.Group


### PR DESCRIPTION
This is a simplest and careless stuff ever can be made to deliver an option, although I (and I think others) would use it. 

As option:
- HideMode.Never: cares about if it is never hidden, then it got to make palce for it. And restrict the usable area of the screen. 
- HideMode.Always: Hide when it is not focused.
- HideMode.On-Overlap: calculates does it overlapped or not. 

This option makes that possible, even when it is overlapped, it will be visible. This can make thames use it a bit differently and make design which works with this option also. 
Design option: 
![image](https://github.com/user-attachments/assets/d6649871-9a0d-4761-b464-a3645ca749f5)

It is overlapped, but visible (and by default "always on-top").
(theme is not included, the current commit is not targeted the theme itself)

This does not need any big extra effort, as it does not offer any extra functionality (hide or makes place exclusive). Everything work as desired. Only hide mechanism needed to be corrected to be able to handle extra case. 