### PR TITLE
Webapp pinning issue #193

### DIFF
--- a/src/apps/seelenweg/modules/shared/store/app.ts
+++ b/src/apps/seelenweg/modules/shared/store/app.ts
@@ -32,7 +32,7 @@ function removeAppFromState(
   state: RootState,
   searched: ExtendedPinnedWegItem | ExtendedTemporalWegItem,
 ) {
-  const search = (app: SwItem) => 'path' in app && app.path === searched.path;
+  const search = (app: SwItem) => 'execution_command' in app && app.execution_command === searched.execution_command;
 
   let index = state.itemsOnLeft.findIndex(search);
   if (index !== -1) {


### PR DESCRIPTION
The pinning is made from 2 step: 
- Remove temporal app
- Add pinned app

Remove temporal app was based on path, which is not appropriate. Execution command is the right way to find the appropriate element to remove. This made possible to not find the right item and add the same item (with the same key - execution command), and got an exception. After that, the exception propagated any time, when did any move and caused multiple visual issue. 

These are all webapps:
<img width="55" alt="image" src="https://github.com/user-attachments/assets/8d48e7f5-8dac-4ccb-a100-41df8ef0321f">

