### PR TITLE
Style issue with a behaviour association

### DIFF
--- a/src/apps/seelenweg/components/WithContextMenu.tsx
+++ b/src/apps/seelenweg/components/WithContextMenu.tsx
@@ -7,9 +7,10 @@ import { BackgroundByLayersV2 } from './BackgroundByLayers/infra';
 
 interface Props extends PropsWithChildren {
   items: ItemType<MenuItemType>[];
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
-export function WithContextMenu({ children, items }: Props) {
+export function WithContextMenu({ children, items, onOpenChange }: Props) {
   const [openContextMenu, setOpenContextMenu] = useState(false);
 
   useWindowFocusChange((focused) => {
@@ -22,7 +23,11 @@ export function WithContextMenu({ children, items }: Props) {
     <Dropdown
       placement="topLeft"
       open={openContextMenu}
-      onOpenChange={setOpenContextMenu}
+      onOpenChange={(isOpen) => {
+        setOpenContextMenu(isOpen);
+        if (onOpenChange)
+          onOpenChange(isOpen);
+      }}
       trigger={['contextMenu']}
       dropdownRender={() => (
         <BackgroundByLayersV2

--- a/src/apps/seelenweg/components/WithContextMenu.tsx
+++ b/src/apps/seelenweg/components/WithContextMenu.tsx
@@ -30,16 +30,22 @@ export function WithContextMenu({ children, items, onOpenChange }: Props) {
       }}
       trigger={['contextMenu']}
       dropdownRender={() => (
-        <BackgroundByLayersV2
-          className="weg-context-menu-container"
-          prefix="menu"
-        >
-          <Menu
-            className="weg-context-menu"
-            onMouseMoveCapture={(e) => e.stopPropagation()}
-            items={items}
-          />
-        </BackgroundByLayersV2>
+        items.length != 0 ?
+          (<BackgroundByLayersV2
+            className="weg-context-menu-container"
+            prefix="menu"
+            onContextMenu={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+            }}
+          >
+            <Menu
+              className="weg-context-menu"
+              onMouseMoveCapture={(e) => e.stopPropagation()}
+              items={items}
+            />
+          </BackgroundByLayersV2>) :
+          <></>
       )}
     >
       {children}

--- a/src/apps/seelenweg/components/WithContextMenu.tsx
+++ b/src/apps/seelenweg/components/WithContextMenu.tsx
@@ -25,27 +25,26 @@ export function WithContextMenu({ children, items, onOpenChange }: Props) {
       open={openContextMenu}
       onOpenChange={(isOpen) => {
         setOpenContextMenu(isOpen);
-        if (onOpenChange)
+        if (onOpenChange) {
           onOpenChange(isOpen);
+        }
       }}
       trigger={['contextMenu']}
       dropdownRender={() => (
-        items.length != 0 ?
-          (<BackgroundByLayersV2
-            className="weg-context-menu-container"
-            prefix="menu"
-            onContextMenu={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-            }}
-          >
-            <Menu
-              className="weg-context-menu"
-              onMouseMoveCapture={(e) => e.stopPropagation()}
-              items={items}
-            />
-          </BackgroundByLayersV2>) :
-          <></>
+        <BackgroundByLayersV2
+          className="weg-context-menu-container"
+          prefix="menu"
+          onContextMenu={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+        >
+          <Menu
+            className="weg-context-menu"
+            onMouseMoveCapture={(e) => e.stopPropagation()}
+            items={items}
+          />
+        </BackgroundByLayersV2>
       )}
     >
       {children}

--- a/src/apps/seelenweg/modules/bar/index.tsx
+++ b/src/apps/seelenweg/modules/bar/index.tsx
@@ -149,6 +149,8 @@ export function SeelenWeg() {
   const isHorizontal =
     settings.position === SeelenWegSide.Top || settings.position === SeelenWegSide.Bottom;
 
+  const projectSwItem = (item: SwItem) => ItemByType(item, (isOpen) => setAssociatedViewCounter((current) => calculateAssociatedViewCounter(current, isOpen)));
+
   return (
     <WithContextMenu items={getSeelenWegMenu(t)}>
       <Reorder.Group
@@ -165,7 +167,7 @@ export function SeelenWeg() {
         })}>
         <BackgroundByLayersV2 prefix="taskbar" />
         {[
-          ...pinnedOnLeft.map((item: SwItem) => ItemByType(item, (isOpen) => setAssociatedViewCounter(calculateAssociatedViewCounter(associatedViewCounter, isOpen)))),
+          ...pinnedOnLeft.map(projectSwItem),
           <Reorder.Item
             as="div"
             key="separator1"
@@ -176,7 +178,7 @@ export function SeelenWeg() {
             drag={false}
             style={getSeparatorComplementarySize(pinnedOnLeft.length, pinnedOnCenter.length)}
           />,
-          ...pinnedOnCenter.map((item: SwItem) => ItemByType(item, (isOpen) => setAssociatedViewCounter(calculateAssociatedViewCounter(associatedViewCounter, isOpen)))),
+          ...pinnedOnCenter.map(projectSwItem),
           <Reorder.Item
             as="div"
             key="separator2"
@@ -187,7 +189,7 @@ export function SeelenWeg() {
             drag={false}
             style={getSeparatorComplementarySize(pinnedOnRight.length, pinnedOnCenter.length)}
           />,
-          ...pinnedOnRight.map((item: SwItem) => ItemByType(item, (isOpen) => setAssociatedViewCounter(calculateAssociatedViewCounter(associatedViewCounter, isOpen)))),
+          ...pinnedOnRight.map(projectSwItem),
         ]}
       </Reorder.Group>
     </WithContextMenu>

--- a/src/apps/seelenweg/modules/item/infra/DraggableItem.tsx
+++ b/src/apps/seelenweg/modules/item/infra/DraggableItem.tsx
@@ -3,11 +3,14 @@ import { PropsWithChildren, useRef } from 'react';
 
 import { SwItem } from '../../shared/store/domain';
 
+import { cx } from '../../../../shared/styles';
+
 interface Props extends PropsWithChildren {
   item: SwItem;
+  className: String | undefined;
 }
 
-export function DraggableItem({ children, item }: Props) {
+export function DraggableItem({ children, item, className }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   return (
@@ -16,7 +19,7 @@ export function DraggableItem({ children, item }: Props) {
       ref={ref}
       value={item}
       drag
-      className="weg-item-drag-container"
+      className={cx('weg-item-drag-container', className)}
       onDragStart={() => {
         ref.current?.classList.add('dragging');
       }}

--- a/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
+++ b/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
@@ -101,17 +101,20 @@ export const UserApplication = memo(({ item, onItemAssociatedViewOpenChanged }: 
           trigger="hover"
           arrow={false}
           content={
-            <BackgroundByLayersV2
-              className="weg-item-preview-container"
-              onMouseMoveCapture={(e) => e.stopPropagation()}
-              prefix="preview"
-            >
-              <div className="weg-item-preview-scrollbar">
-                {item.opens.map((hwnd) => (
-                  <UserApplicationPreview key={hwnd} hwnd={hwnd} />
-                ))}
-              </div>
-            </BackgroundByLayersV2>
+            <WithContextMenu items={[]}>
+              <BackgroundByLayersV2
+                className="weg-item-preview-container"
+                onMouseMoveCapture={(e) => e.stopPropagation()}
+                onContextMenu={(e) => e.stopPropagation()}
+                prefix="preview"
+              >
+                <div className="weg-item-preview-scrollbar">
+                  {item.opens.map((hwnd) => (
+                    <UserApplicationPreview key={hwnd} hwnd={hwnd} />
+                  ))}
+                </div>
+              </BackgroundByLayersV2>
+            </WithContextMenu>
           }
         >
           <div

--- a/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
+++ b/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
@@ -104,7 +104,7 @@ export const UserApplication = memo(({ item, onAssociatedViewOpenChanged }: Prop
           content={
             <WithContextMenu items={[]}>
               <BackgroundByLayersV2
-                className="weg-item-preview-container"
+                className={ cx('weg-item-preview-container', settings.position.toLowerCase()) }
                 onMouseMoveCapture={(e) => e.stopPropagation()}
                 onContextMenu={(e) => e.stopPropagation()}
                 prefix="preview"

--- a/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
+++ b/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
@@ -25,10 +25,11 @@ import { UserApplicationPreview } from './UserApplicationPreview';
 
 interface Props {
   item: ExtendedPinnedWegItem | ExtendedTemporalWegItem;
-  onItemAssociatedViewOpenChanged?: (isOpen: boolean) => void;
+  // This will be triggered in case preview or context menu is opened from this item, or both of them closed.
+  onAssociatedViewOpenChanged?: (isOpen: boolean) => void;
 }
 
-export const UserApplication = memo(({ item, onItemAssociatedViewOpenChanged }: Props) => {
+export const UserApplication = memo(({ item, onAssociatedViewOpenChanged }: Props) => {
   const isFocused = useSelector(
     (state: RootState) => state.focusedApp && item.opens.includes(state.focusedApp.hwnd),
   );
@@ -80,8 +81,8 @@ export const UserApplication = memo(({ item, onItemAssociatedViewOpenChanged }: 
   }, [item]);
 
   useEffect(() => {
-    if (onItemAssociatedViewOpenChanged) {
-      onItemAssociatedViewOpenChanged(openPreview || openContextMenu);
+    if (onAssociatedViewOpenChanged) {
+      onAssociatedViewOpenChanged(openPreview || openContextMenu);
     }
   }, [openPreview || openContextMenu]);
 

--- a/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
+++ b/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
@@ -102,20 +102,21 @@ export const UserApplication = memo(({ item, onAssociatedViewOpenChanged }: Prop
           trigger="hover"
           arrow={false}
           content={
-            <WithContextMenu items={[]}>
-              <BackgroundByLayersV2
-                className={ cx('weg-item-preview-container', settings.position.toLowerCase()) }
-                onMouseMoveCapture={(e) => e.stopPropagation()}
-                onContextMenu={(e) => e.stopPropagation()}
-                prefix="preview"
-              >
-                <div className="weg-item-preview-scrollbar">
-                  {item.opens.map((hwnd) => (
-                    <UserApplicationPreview key={hwnd} hwnd={hwnd} />
-                  ))}
-                </div>
-              </BackgroundByLayersV2>
-            </WithContextMenu>
+            <BackgroundByLayersV2
+              className={ cx('weg-item-preview-container', settings.position.toLowerCase()) }
+              onMouseMoveCapture={(e) => e.stopPropagation()}
+              onContextMenu={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+              }}
+              prefix="preview"
+            >
+              <div className="weg-item-preview-scrollbar">
+                {item.opens.map((hwnd) => (
+                  <UserApplicationPreview key={hwnd} hwnd={hwnd} />
+                ))}
+              </div>
+            </BackgroundByLayersV2>
           }
         >
           <div

--- a/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
+++ b/src/apps/seelenweg/modules/item/infra/UserApplication.tsx
@@ -87,7 +87,7 @@ export const UserApplication = memo(({ item, onAssociatedViewOpenChanged }: Prop
   }, [openPreview || openContextMenu]);
 
   return (
-    <DraggableItem item={item} className={cx({ 'opened-associated-view': openPreview || openContextMenu })}>
+    <DraggableItem item={item} className={cx({ 'associated-view-open': openPreview || openContextMenu })}>
       <WithContextMenu items={getMenuForItem(t, item) || []} onOpenChange={(isOpen) => {
         setOpenContextMenu(isOpen);
         if (openPreview && isOpen) {

--- a/src/apps/toolbar/modules/Date/Calendar.tsx
+++ b/src/apps/toolbar/modules/Date/Calendar.tsx
@@ -31,7 +31,7 @@ function DateCalendar() {
   }, []);
 
   return (
-    <BackgroundByLayersV2 className="calendar-container" prefix="calendar">
+    <BackgroundByLayersV2 className="calendar-container" prefix="calendar" onContextMenu={(e) => e.stopPropagation()}>
       <div onWheel={onWheel}>
         <MomentCalendar
           value={date}

--- a/src/apps/toolbar/modules/Notifications/infra/ArrivalPreview.tsx
+++ b/src/apps/toolbar/modules/Notifications/infra/ArrivalPreview.tsx
@@ -51,7 +51,7 @@ export function ArrivalPreview() {
   }, [notifications]);
 
   return (
-    <BackgroundByLayersV2 className="notification-arrival">
+    <BackgroundByLayersV2 className="notification-arrival" onContextMenu={(e) => e.stopPropagation()}>
       <AnimatePresence>
         {currentNotificationPreviewSet &&
           currentNotificationPreviewSet.map((notification) => {

--- a/src/apps/toolbar/modules/Notifications/infra/Notifications.tsx
+++ b/src/apps/toolbar/modules/Notifications/infra/Notifications.tsx
@@ -22,7 +22,7 @@ export function Notifications() {
   const notifications = useSelector(Selectors.notifications);
 
   return (
-    <BackgroundByLayersV2 className="notifications">
+    <BackgroundByLayersV2 className="notifications" onContextMenu={(e) => e.stopPropagation()}>
       <div className="notifications-header">
         <span>Notifications</span>
         <Button

--- a/src/apps/toolbar/modules/Settings/infra.tsx
+++ b/src/apps/toolbar/modules/Settings/infra.tsx
@@ -70,7 +70,7 @@ export function SettingsModule({ module }: Props) {
       onOpenChange={setOpenPreview}
       arrow={false}
       content={
-        <div className="fast-settings">
+        <div className="fast-settings" onContextMenu={(e) => e.stopPropagation()}>
           <BackgroundByLayersV2 prefix="fast-settings" />
           <div className="fast-settings-title">
             <span>{t('settings.title')}</span>

--- a/src/apps/toolbar/modules/Tray/index.tsx
+++ b/src/apps/toolbar/modules/Tray/index.tsx
@@ -87,7 +87,7 @@ export function TrayModule({ module }: Props) {
       onOpenChange={setOpenPreview}
       arrow={false}
       content={
-        <BackgroundByLayersV2 className="tray" prefix="tray">
+        <BackgroundByLayersV2 className="tray" prefix="tray" onContextMenu={(e) => e.stopPropagation()}>
           <ul className="tray-list">
             {trayList.map((tray, idx) => (
               <TrayItem key={idx} idx={idx} tray={tray} onAction={() => setOpenPreview(false)} />

--- a/src/apps/toolbar/modules/media/infra/MediaControls.tsx
+++ b/src/apps/toolbar/modules/media/infra/MediaControls.tsx
@@ -211,7 +211,7 @@ function MediaControls() {
   const sessions = useSelector(Selectors.mediaSessions);
 
   return (
-    <BackgroundByLayersV2 className="media-control">
+    <BackgroundByLayersV2 className="media-control" onContextMenu={(e) => e.stopPropagation()}>
       <span className="media-control-label">{t('media.master_volume')}</span>
       {!!defaultOutput && (
         <VolumeControl
@@ -314,7 +314,7 @@ export function WithMediaControls({ children }: PropsWithChildren) {
         trigger={[]}
         destroyTooltipOnHide
         content={
-          <BackgroundByLayersV2 className="media-notifier">
+          <BackgroundByLayersV2 className="media-notifier" onContextMenu={(e) => e.stopPropagation()}>
             {defaultOutput && (
               <VolumeControl
                 value={defaultOutput.volume}

--- a/src/apps/toolbar/modules/network/infra/WlanSelector.tsx
+++ b/src/apps/toolbar/modules/network/infra/WlanSelector.tsx
@@ -56,7 +56,7 @@ function WlanSelector({ open }: { open: boolean }) {
   );
 
   return (
-    <div className="wlan-selector">
+    <div className="wlan-selector" onContextMenu={(e) => e.stopPropagation()}>
       <BackgroundByLayersV2 prefix="wlan-selector" />
 
       {connected && (

--- a/static/themes/default/theme.launcher.css
+++ b/static/themes/default/theme.launcher.css
@@ -22,6 +22,24 @@ body {
   translate: -50% -50%;
   height: 50lvh;
   aspect-ratio: 1 / 1;
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-400);
+    border-radius: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: var(--color-gray-500);
+  }
 }
 
 .launcher {

--- a/static/themes/default/theme.toolbar.css
+++ b/static/themes/default/theme.toolbar.css
@@ -11,7 +11,7 @@
   }
 }
 
-#root {
+#root, .fast-settings, .tray, .wlan-selector, .media-control, .notifications, .notification-arrival, .calendar-container {
   font-size: 0.8rem;
   font-weight: 500;
 


### PR DESCRIPTION
Ok, this will be a bit hard, will make some video to understand it more clearly. 

Issue: When you leave weg for a blink, it closes the weg bar in case of HideMode.Always & HideMode.On-Overlap

First: It is currently working.
Side note: because in default style, we have a glitch: 
![image](https://github.com/user-attachments/assets/2119029d-5736-4b62-afce-e0e4f64acc8b)
In this image it seems when you move to preview, it leaves the weg bar... but in the reality, the preview hops under your mouse: 
![image](https://github.com/user-attachments/assets/0fa21289-3078-49b3-9668-9f6dce2d07fc)

If you have different style, it behaves as I described: 

https://github.com/user-attachments/assets/45e5003d-9d9f-4123-b3c2-6757e2b1ac61

For this to remain open and correct logic to expand I got to wire in the associated pop-ups in the logic. This behaviour is gone with this. 

For better style options I gave a possibility to style the opened item whose associatedPopup is opened.
class: 'opened-associated-view'

Hereby you can style like this (Mosue is on preview item / context menu): 
![image](https://github.com/user-attachments/assets/05325710-5e6d-413b-8ca4-05e2bbb5baf7)
![image](https://github.com/user-attachments/assets/2d26d1ec-6c14-4b54-8cdf-291dedae6f9b)
Pre:
![image](https://github.com/user-attachments/assets/0202c96f-07ce-454a-9f9d-85f6e2bc0ce4)

The "can" and "should" does not comes together; the styles I did not change for now. 

Other change: 
Closes the preview items in case of weg item context menu. This is mostly unintended I think: 
![image](https://github.com/user-attachments/assets/d48a55d6-d338-4e91-b71a-c93d9d1e7c02)



