### PR TITLE
Resolution, tablet, orientation change propagation

### DIFF
--- a/src/apps/seelenweg/modules/bar/index.tsx
+++ b/src/apps/seelenweg/modules/bar/index.tsx
@@ -57,6 +57,7 @@ export function SeelenWeg() {
 
   const settings = useSelector(Selectors.settings);
   const isOverlaped = useSelector(Selectors.isOverlaped);
+  const monitorInfo = useSelector(Selectors.monitorInfo);
 
   const pinnedOnLeft = useSelector(Selectors.itemsOnLeft);
   const pinnedOnCenter = useSelector(Selectors.itemsOnCenter);
@@ -147,11 +148,12 @@ export function SeelenWeg() {
         values={[...pinnedOnLeft, Separator1, ...pinnedOnCenter, Separator2, ...pinnedOnRight]}
         onReorder={onReorderPinned}
         axis={isHorizontal ? 'x' : 'y'}
-        className={cx('taskbar', settings.position.toLowerCase(), {
+        className={cx('taskbar', settings.position.toLowerCase(), monitorInfo.orientation.toLowerCase(), {
           horizontal: isHorizontal,
           vertical: !isHorizontal,
           'full-width': settings.mode === SeelenWegMode.FullWidth,
           hidden: shouldBeHidden(settings.hideMode, isActive, isOverlaped),
+          tabletMode: monitorInfo.isTabletMode,
           delayed,
         })}
       >

--- a/src/apps/seelenweg/modules/bar/index.tsx
+++ b/src/apps/seelenweg/modules/bar/index.tsx
@@ -57,7 +57,6 @@ export function SeelenWeg() {
 
   const settings = useSelector(Selectors.settings);
   const isOverlaped = useSelector(Selectors.isOverlaped);
-  const monitorInfo = useSelector(Selectors.monitorInfo);
 
   const pinnedOnLeft = useSelector(Selectors.itemsOnLeft);
   const pinnedOnCenter = useSelector(Selectors.itemsOnCenter);
@@ -148,12 +147,11 @@ export function SeelenWeg() {
         values={[...pinnedOnLeft, Separator1, ...pinnedOnCenter, Separator2, ...pinnedOnRight]}
         onReorder={onReorderPinned}
         axis={isHorizontal ? 'x' : 'y'}
-        className={cx('taskbar', settings.position.toLowerCase(), monitorInfo.orientation.toLowerCase(), {
+        className={cx('taskbar', settings.position.toLowerCase(), {
           horizontal: isHorizontal,
           vertical: !isHorizontal,
           'full-width': settings.mode === SeelenWegMode.FullWidth,
           hidden: shouldBeHidden(settings.hideMode, isActive, isOverlaped),
-          tabletMode: monitorInfo.isTabletMode,
           delayed,
         })}
       >

--- a/src/apps/seelenweg/modules/shared/store/app.ts
+++ b/src/apps/seelenweg/modules/shared/store/app.ts
@@ -1,5 +1,5 @@
 import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
-import { PinnedWegItem, SeelenWegSettings, SwItemType, UIColors } from 'seelen-core';
+import { MonitorOrientation, PinnedWegItem, SeelenWegSettings, SwItemType, UIColors } from 'seelen-core';
 
 import { SwTemporalAppUtils } from '../../item/app/TemporalApp';
 
@@ -23,6 +23,12 @@ const initialState: RootState = {
   openApps: {},
   focusedApp: null,
   isOverlaped: false,
+  monitorInfo: {
+    id: '',
+    index: 0,
+    orientation: MonitorOrientation.HorizontalNormal,
+    is_tablet_mode: false,
+  },
   settings: new SeelenWegSettings(),
   mediaSessions: [],
   colors: UIColors.default(),
@@ -118,6 +124,12 @@ export const RootSlice = createSlice({
         });
       }
       savePinnedItems(current(state));
+    },
+    updateTabletMode(state, current) {
+      state.monitorInfo.isTabletMode = current.payload;
+    },
+    updateOrientation(state, current) {
+      state.monitorInfo.orientation = current.payload;
     },
     removeMediaModule(state) {
       const filter = (current: SwItem) => current.type !== SwItemType.Media;

--- a/src/apps/seelenweg/modules/shared/store/domain.ts
+++ b/src/apps/seelenweg/modules/shared/store/domain.ts
@@ -1,6 +1,7 @@
 import { modify } from 'readable-types';
 import {
   MediaWegItem,
+  MonitorInfo,
   PinnedWegItem,
   SeelenWegSettings,
   SeparatorWegItem,
@@ -74,5 +75,6 @@ export interface RootState extends IRootState<SeelenWegSettings> {
   // ----------------------
   focusedApp: FocusedApp | null;
   isOverlaped: boolean;
+  monitorInfo: MonitorInfo;
   mediaSessions: MediaSession[];
 }

--- a/src/apps/seelenweg/modules/shared/store/infra.ts
+++ b/src/apps/seelenweg/modules/shared/store/infra.ts
@@ -3,6 +3,7 @@ import { listen as listenGlobal } from '@tauri-apps/api/event';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { debounce } from 'lodash';
 import {
+  MonitorOrientation,
   SeelenEvent,
   SeelenWegSettings,
   SeelenWegSide,
@@ -21,7 +22,7 @@ import { UserSettingsLoader } from '../../../../settings/modules/shared/store/st
 import { FocusedApp } from '../../../../shared/interfaces/common';
 import { StartThemingTool } from '../../../../shared/styles';
 import i18n from '../../../i18n';
-import { IsSavingPinnedItems, loadPinnedItems } from './storeApi';
+import { IsSavingPinnedItems, loadMonitorInfo, loadPinnedItems } from './storeApi';
 
 export const store = configureStore({
   reducer: RootSlice.reducer,
@@ -69,6 +70,14 @@ export async function registerStoreEvents() {
 
   await view.listen<boolean>('set-auto-hide', (event) => {
     store.dispatch(RootActions.setIsOverlaped(event.payload));
+  });
+
+  await view.listen<boolean>('tablet-mode-changed', (event) => {
+    store.dispatch(RootActions.updateTabletMode(event.payload));
+  });
+
+  await view.listen<MonitorOrientation>('orientation-changed', (event) => {
+    store.dispatch(RootActions.updateOrientation(event.payload));
   });
 
   await listenGlobal<AppFromBackground[]>('add-multiple-open-apps', async (event) => {
@@ -197,4 +206,5 @@ export async function loadStore() {
   store.dispatch(RootActions.setItemsOnLeft(await cleanSavedItems(apps.left)));
   store.dispatch(RootActions.setItemsOnCenter(await cleanSavedItems(apps.center)));
   store.dispatch(RootActions.setItemsOnRight(await cleanSavedItems(apps.right)));
+  store.dispatch(RootActions.setMonitorInfo(await loadMonitorInfo()));
 }

--- a/src/apps/seelenweg/modules/shared/store/storeApi.ts
+++ b/src/apps/seelenweg/modules/shared/store/storeApi.ts
@@ -3,7 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
 import yaml from 'js-yaml';
 import { debounce } from 'lodash';
-import { SwItemType, WegItem, WegItems } from 'seelen-core';
+import { MonitorInfo, SeelenCommand, SwItemType, WegItem, WegItems } from 'seelen-core';
 
 import { store } from './infra';
 
@@ -49,4 +49,8 @@ export const savePinnedItems = debounce(
 
 export const loadPinnedItems = async (): Promise<WegItems> => {
   return invoke<WegItems>('state_get_weg_items');
+};
+
+export const loadMonitorInfo = async (): Promise<MonitorInfo> => {
+  return invoke<MonitorInfo>(SeelenCommand.RequestMonitorInfo);
 };

--- a/src/apps/toolbar/modules/main/infra.tsx
+++ b/src/apps/toolbar/modules/main/infra.tsx
@@ -79,7 +79,6 @@ export function ToolBar({ structure }: Props) {
   const plugins = useSelector(Selectors.plugins);
   const isOverlaped = useSelector(Selectors.isOverlaped);
   const hideMode = useSelector(Selectors.settings.hideMode);
-  const monitorInfo = useSelector(Selectors.monitorInfo);
 
   const dispatch = useDispatch();
   const [forceUpdate] = useForceUpdate();
@@ -154,8 +153,7 @@ export function ToolBar({ structure }: Props) {
           ...structure.right,
         ]}
         onReorder={onReorderPinned}
-        className={cx('ft-bar', monitorInfo.orientation.toLowerCase(), {
-          tabletMode: monitorInfo.isTabletMode,
+        className={cx('ft-bar', {
           'ft-bar-hidden': shouldBeHidden,
           'ft-bar-delayed': delayed,
         })}

--- a/src/apps/toolbar/modules/main/infra.tsx
+++ b/src/apps/toolbar/modules/main/infra.tsx
@@ -79,6 +79,7 @@ export function ToolBar({ structure }: Props) {
   const plugins = useSelector(Selectors.plugins);
   const isOverlaped = useSelector(Selectors.isOverlaped);
   const hideMode = useSelector(Selectors.settings.hideMode);
+  const monitorInfo = useSelector(Selectors.monitorInfo);
 
   const dispatch = useDispatch();
   const [forceUpdate] = useForceUpdate();
@@ -153,7 +154,8 @@ export function ToolBar({ structure }: Props) {
           ...structure.right,
         ]}
         onReorder={onReorderPinned}
-        className={cx('ft-bar', {
+        className={cx('ft-bar', monitorInfo.orientation.toLowerCase(), {
+          tabletMode: monitorInfo.isTabletMode,
           'ft-bar-hidden': shouldBeHidden,
           'ft-bar-delayed': delayed,
         })}

--- a/src/apps/toolbar/modules/shared/store/app.ts
+++ b/src/apps/toolbar/modules/shared/store/app.ts
@@ -1,5 +1,5 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { FancyToolbarSettings, UIColors } from 'seelen-core';
+import { FancyToolbarSettings, MonitorOrientation, UIColors } from 'seelen-core';
 import { Placeholder, ToolbarModule } from 'seelen-core';
 
 import { RootState } from './domain';
@@ -12,6 +12,12 @@ const initialState: RootState = {
   plugins: [],
   dateFormat: '',
   isOverlaped: false,
+  monitorInfo: {
+    id: '',
+    index: 0,
+    orientation: MonitorOrientation.horizontalNormal,
+    isTabletMode: false,
+  },
   focused: null,
   settings: new FancyToolbarSettings(),
   env: {},
@@ -47,6 +53,12 @@ export const RootSlice = createSlice({
     setPlaceholder(state, action: PayloadAction<Placeholder | null>) {
       state.placeholder = action.payload;
       state.version++;
+    },
+    updateTabletMode(state, current) {
+      state.monitorInfo.isTabletMode = current.payload;
+    },
+    updateOrientation(state, current) {
+      state.monitorInfo.orientation = current.payload;
     },
     setItemsOnLeft(state, action: PayloadAction<ToolbarModule[]>) {
       if (state.placeholder) {

--- a/src/apps/toolbar/modules/shared/store/domain.ts
+++ b/src/apps/toolbar/modules/shared/store/domain.ts
@@ -1,5 +1,5 @@
 import { SoftOpaque } from 'readable-types';
-import { FancyToolbarSettings, Settings } from 'seelen-core';
+import { FancyToolbarSettings, MonitorInfo, Settings } from 'seelen-core';
 import { Placeholder, Plugin } from 'seelen-core';
 
 import { WlanBssEntry } from '../../network/domain';
@@ -116,6 +116,7 @@ export interface RootState extends IRootState<FancyToolbarSettings>, Pick<Settin
   plugins: Plugin[];
 
   isOverlaped: boolean;
+  monitorInfo: MonitorInfo;
   focused: FocusedApp | null;
   env: Record<string, string>;
   powerStatus: PowerStatus;

--- a/src/apps/toolbar/modules/shared/store/infra.ts
+++ b/src/apps/toolbar/modules/shared/store/infra.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { listen as listenGlobal } from '@tauri-apps/api/event';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { debounce, throttle } from 'lodash';
-import { PluginList, SeelenEvent, UIColors } from 'seelen-core';
+import { MonitorOrientation, PluginList, SeelenEvent, UIColors } from 'seelen-core';
 import { FancyToolbarSettings } from 'seelen-core';
 
 import { IsSavingCustom } from '../../main/application';
@@ -26,6 +26,7 @@ import { UserSettingsLoader } from '../../../../settings/modules/shared/store/st
 import { FocusedApp } from '../../../../shared/interfaces/common';
 import { StartThemingTool } from '../../../../shared/styles';
 import i18n from '../../../i18n';
+import { loadMonitorInfo } from './storeApi';
 
 export const store = configureStore({
   reducer: RootSlice.reducer,
@@ -49,6 +50,14 @@ export async function registerStoreEvents() {
 
   await view.listen<boolean>('set-auto-hide', (event) => {
     store.dispatch(RootActions.setIsOverlaped(event.payload));
+  });
+
+  await view.listen<boolean>('tablet-mode-changed', (event) => {
+    store.dispatch(RootActions.updateTabletMode(event.payload));
+  });
+
+  await view.listen<MonitorOrientation>('orientation-changed', (event) => {
+    store.dispatch(RootActions.updateOrientation(event.payload));
   });
 
   const onFocusChanged = debounce((app: FocusedApp) => {
@@ -161,6 +170,7 @@ export async function loadStore() {
   setPlaceholder(userSettings);
 
   store.dispatch(RootActions.setEnv(userSettings.env));
+  store.dispatch(RootActions.setMonitorInfo(await loadMonitorInfo()));
 }
 
 export function loadSettingsCSS(settings: FancyToolbarSettings) {

--- a/src/apps/toolbar/modules/shared/store/storeApi.ts
+++ b/src/apps/toolbar/modules/shared/store/storeApi.ts
@@ -1,0 +1,6 @@
+import { invoke } from '@tauri-apps/api/core';
+import { MonitorInfo } from 'seelen-core';
+
+export const loadMonitorInfo = async (): Promise<MonitorInfo> => {
+  return invoke<MonitorInfo>('get_monitor_info');
+};

--- a/src/background/exposed.rs
+++ b/src/background/exposed.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use seelen_core::state::MonitorInfo;
 use tauri::{Builder, WebviewWindow, Wry};
 use tauri_plugin_shell::ShellExt;
 
@@ -18,6 +19,7 @@ use crate::seelen_wm_v2::handler::*;
 use crate::state::infrastructure::*;
 use crate::system::brightness::*;
 use crate::utils::is_virtual_desktop_supported as virtual_desktop_supported;
+use crate::windows_api::window::Window;
 use crate::windows_api::WindowsApi;
 use crate::winevent::{SyntheticFullscreenData, WinEvent};
 use crate::{log_error, utils};
@@ -28,6 +30,20 @@ use crate::modules::notifications::infrastructure::*;
 use crate::modules::power::infrastructure::*;
 use crate::modules::system_settings::infrastructure::*;
 use crate::modules::tray::infrastructure::*;
+
+#[tauri::command(async)]
+pub fn get_monitor_info(window: tauri::Window) -> Result<MonitorInfo> {
+    let monitor = Window::from(window.hwnd()?).monitor();
+
+    let result = MonitorInfo {
+        id: monitor.id()?,
+        index: monitor.index()?,
+        orientation: *monitor.display_orientation(),
+        is_tablet_mode: *monitor.tablet_mode(),
+    };
+
+    Ok(result)
+}
 
 #[tauri::command(async)]
 fn select_file_on_explorer(path: String) -> Result<()> {
@@ -177,6 +193,7 @@ pub fn register_invoke_handler(app_builder: Builder<Wry>) -> Builder<Wry> {
         simulate_fullscreen,
         check_for_updates,
         install_last_available_update,
+        get_monitor_info,
         // Seelen Settings
         set_auto_start,
         get_auto_start_status,

--- a/src/background/instance.rs
+++ b/src/background/instance.rs
@@ -47,7 +47,22 @@ impl SeelenInstanceContainer {
             self.handle = id;
             self.monitor = Monitor::from(id);
         } else {
+            #[allow(clippy::clone_on_copy)]
+            let before_update = self.monitor.clone();
             self.monitor.update().ok();
+
+            if *self.monitor.display_orientation() != *before_update.display_orientation() {
+                log::trace!(
+                    "Orientation changed to {:?}!",
+                    self.monitor.display_orientation()
+                )
+            }
+            if *self.monitor.tablet_mode() != *before_update.tablet_mode() {
+                log::trace!(
+                    "Touch priority changed to {:?}!",
+                    self.monitor.tablet_mode()
+                )
+            }
         }
     }
 

--- a/src/background/instance.rs
+++ b/src/background/instance.rs
@@ -2,7 +2,6 @@ use getset::{Getters, MutGetters};
 
 use crate::{
     error_handler::Result,
-    log_error,
     seelen_bar::FancyToolbar,
     seelen_weg::SeelenWeg,
     seelen_wm_v2::instance::WindowManagerV2,
@@ -44,9 +43,12 @@ impl SeelenInstanceContainer {
     }
 
     pub fn update_handle(&mut self, id: HMONITOR) {
-        self.handle = id;
-        self.monitor = Monitor::from(id);
-        log_error!(self.ensure_positions());
+        if self.handle != id {
+            self.handle = id;
+            self.monitor = Monitor::from(id);
+        } else {
+            self.monitor.update().ok();
+        }
     }
 
     pub fn ensure_positions(&mut self) -> Result<()> {

--- a/src/background/seelen_bar/mod.rs
+++ b/src/background/seelen_bar/mod.rs
@@ -158,6 +158,15 @@ impl FancyToolbar {
         Ok(())
     }
 
+    pub fn propagate_associated_event<S: Serialize + Clone>(
+        &self,
+        event: &str,
+        payload: S,
+    ) -> Result<()> {
+        self.window.emit_to(self.window.label(), event, payload)?;
+        Ok(())
+    }
+
     fn create_window(monitor: &str) -> Result<WebviewWindow> {
         let manager = get_app_handle();
         let label = format!("seelen/fancy-toolbar__query__monitor:{}", monitor);

--- a/src/background/seelen_weg/mod.rs
+++ b/src/background/seelen_weg/mod.rs
@@ -268,6 +268,14 @@ impl SeelenWeg {
         self.set_overlaped_status(is_overlaped)
     }
 
+    pub fn propagate_associated_event<S: Serialize + Clone>(
+        &self,
+        event: &str,
+        payload: S,
+    ) -> Result<()> {
+        self.emit(event, payload)
+    }
+
     pub fn hide(&mut self) -> Result<()> {
         WindowsApi::show_window_async(self.window.hwnd()?, SW_HIDE)?;
         self.window.emit_to(

--- a/src/background/windows_api/mod.rs
+++ b/src/background/windows_api/mod.rs
@@ -48,8 +48,10 @@ use windows::{
                 DWM_CLOAKED_INHERITED, DWM_CLOAKED_SHELL,
             },
             Gdi::{
-                EnumDisplayMonitors, GetMonitorInfoW, MonitorFromPoint, MonitorFromWindow, HDC,
-                HMONITOR, MONITORENUMPROC, MONITORINFOEXW, MONITOR_DEFAULTTOPRIMARY,
+                EnumDisplayMonitors, EnumDisplaySettingsA, GetMonitorInfoW, MonitorFromPoint,
+                MonitorFromWindow, DEVMODEA, DEVMODE_DISPLAY_ORIENTATION, DMDO_DEFAULT,
+                ENUM_CURRENT_SETTINGS, HDC, HMONITOR, MONITORENUMPROC, MONITORINFOEXW,
+                MONITOR_DEFAULTTOPRIMARY,
             },
         },
         Security::{
@@ -88,11 +90,11 @@ use windows::{
                 GetWindowThreadProcessId, IsIconic, IsWindow, IsWindowVisible, IsZoomed,
                 PostMessageW, SetForegroundWindow, SetWindowPos, ShowWindow, ShowWindowAsync,
                 SystemParametersInfoW, ANIMATIONINFO, GWL_EXSTYLE, GWL_STYLE, GW_OWNER, HWND_TOP,
-                SET_WINDOW_POS_FLAGS, SHOW_WINDOW_CMD, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN,
-                SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SPIF_SENDCHANGE, SPIF_UPDATEINIFILE,
-                SPI_GETANIMATION, SPI_GETDESKWALLPAPER, SPI_SETANIMATION, SPI_SETDESKWALLPAPER,
-                SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER,
-                SW_FORCEMINIMIZE, SW_MINIMIZE, SW_NORMAL, SW_RESTORE,
+                SET_WINDOW_POS_FLAGS, SHOW_WINDOW_CMD, SM_CONVERTIBLESLATEMODE, SM_CXVIRTUALSCREEN,
+                SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SPIF_SENDCHANGE,
+                SPIF_UPDATEINIFILE, SPI_GETANIMATION, SPI_GETDESKWALLPAPER, SPI_SETANIMATION,
+                SPI_SETDESKWALLPAPER, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
+                SWP_NOZORDER, SW_FORCEMINIMIZE, SW_MINIMIZE, SW_NORMAL, SW_RESTORE,
                 SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, WINDOW_EX_STYLE, WINDOW_STYLE, WNDENUMPROC,
                 WS_SIZEBOX, WS_THICKFRAME,
             },
@@ -149,6 +151,20 @@ impl WindowsApi {
         }
         .ok()?;
         Ok(())
+    }
+
+    pub fn get_display_orientation() -> Result<DEVMODE_DISPLAY_ORIENTATION> {
+        let mut devmode = DEVMODEA::default();
+        unsafe {
+            if EnumDisplaySettingsA(None, ENUM_CURRENT_SETTINGS, &mut devmode).into() {
+                return Ok(devmode.Anonymous1.Anonymous2.dmDisplayOrientation);
+            }
+        }
+        Ok(DMDO_DEFAULT)
+    }
+
+    pub fn is_in_tablet_mode() -> Result<bool> {
+        Ok(unsafe { GetSystemMetrics(SM_CONVERTIBLESLATEMODE) } == 0)
     }
 
     pub fn enum_windows(callback: WNDENUMPROC, callback_data_address: isize) -> Result<()> {

--- a/src/background/windows_api/monitor.rs
+++ b/src/background/windows_api/monitor.rs
@@ -1,5 +1,8 @@
 use getset::Getters;
-use windows::Win32::{Foundation::RECT, Graphics::Gdi::HMONITOR};
+use windows::Win32::{
+    Foundation::RECT,
+    Graphics::Gdi::{DEVMODE_DISPLAY_ORIENTATION, HMONITOR},
+};
 
 use crate::{error_handler::Result, modules::input::domain::Point};
 
@@ -12,6 +15,10 @@ pub struct Monitor {
     work_area: RECT,
     #[getset(get = "pub")]
     device_pixel_ratio: u32,
+    #[getset(get = "pub")]
+    display_orientation: DEVMODE_DISPLAY_ORIENTATION,
+    #[getset(get = "pub")]
+    tablet_mode: bool,
 }
 
 unsafe impl Send for Monitor {}
@@ -42,12 +49,16 @@ impl Monitor {
             monitor,
             work_area: WindowsApi::monitor_rect(monitor).ok().unwrap(),
             device_pixel_ratio: WindowsApi::get_device_pixel_ratio(monitor).ok().unwrap() as u32,
+            display_orientation: WindowsApi::get_display_orientation().ok().unwrap(),
+            tablet_mode: WindowsApi::is_in_tablet_mode().ok().unwrap(),
         }
     }
 
     pub fn update(&mut self) -> Result<()> {
         self.work_area = WindowsApi::monitor_rect(self.monitor)?;
         self.device_pixel_ratio = WindowsApi::get_device_pixel_ratio(self.monitor)? as u32;
+        self.display_orientation = WindowsApi::get_display_orientation()?;
+        self.tablet_mode = WindowsApi::is_in_tablet_mode()?;
 
         Ok(())
     }

--- a/src/background/windows_api/monitor.rs
+++ b/src/background/windows_api/monitor.rs
@@ -1,44 +1,67 @@
-use windows::Win32::Graphics::Gdi::HMONITOR;
+use getset::Getters;
+use windows::Win32::{Foundation::RECT, Graphics::Gdi::HMONITOR};
 
 use crate::{error_handler::Result, modules::input::domain::Point};
 
 use super::{MonitorEnumerator, WindowsApi};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Monitor(HMONITOR);
+#[derive(Getters, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Monitor {
+    monitor: HMONITOR,
+    #[getset(get = "pub")]
+    work_area: RECT,
+    #[getset(get = "pub")]
+    device_pixel_ratio: u32,
+}
+
 unsafe impl Send for Monitor {}
 unsafe impl Sync for Monitor {}
 
 impl From<HMONITOR> for Monitor {
     fn from(hmonitor: HMONITOR) -> Self {
-        Self(hmonitor)
+        Monitor::new(hmonitor)
     }
 }
 
 impl From<isize> for Monitor {
     fn from(hmonitor: isize) -> Self {
-        Self(HMONITOR(hmonitor as _))
+        Monitor::new(HMONITOR(hmonitor as _))
     }
 }
 
 impl From<&Point> for Monitor {
     fn from(point: &Point) -> Self {
         let hmonitor = WindowsApi::monitor_from_point(point);
-        Self(hmonitor)
+        Monitor::new(hmonitor)
     }
 }
 
 impl Monitor {
+    pub fn new(monitor: HMONITOR) -> Monitor {
+        Monitor {
+            monitor,
+            work_area: WindowsApi::monitor_rect(monitor).ok().unwrap(),
+            device_pixel_ratio: WindowsApi::get_device_pixel_ratio(monitor).ok().unwrap() as u32,
+        }
+    }
+
+    pub fn update(&mut self) -> Result<()> {
+        self.work_area = WindowsApi::monitor_rect(self.monitor)?;
+        self.device_pixel_ratio = WindowsApi::get_device_pixel_ratio(self.monitor)? as u32;
+
+        Ok(())
+    }
+
     pub fn raw(&self) -> HMONITOR {
-        self.0
+        self.monitor
     }
 
     pub fn id(&self) -> Result<String> {
-        WindowsApi::monitor_name(self.0)
+        WindowsApi::monitor_name(self.monitor)
     }
 
     pub fn index(&self) -> Result<usize> {
-        WindowsApi::monitor_index(self.0)
+        WindowsApi::monitor_index(self.monitor)
     }
 
     pub fn at(index: usize) -> Option<Monitor> {


### PR DESCRIPTION
The modification stores the resolution and DPI in monitor instance. In case of DPI or resolution changes, modified, the updated logic, which now capable to handle these associated events also. 
![image](https://github.com/user-attachments/assets/47edfcb4-d87d-4982-abe9-173acc902baa)


The event logic modified via channels.
![image](https://github.com/user-attachments/assets/9564cec5-4512-4f50-8d09-67c0269270de)

 The channel modification handlers instead of call to instance immediately, calls reorganise on Seelen.
![image](https://github.com/user-attachments/assets/99d7113a-6553-453b-b71d-17bd1c16c6e5)

 This way, wall will be notified also. In case there is direct monitor way of reposition, only the associated instance will be reorganised.
![image](https://github.com/user-attachments/assets/28feb54c-b0d5-47d5-94fb-fc6dc4a4064e)

