### PR TITLE
Notification Icons

### DIFF
--- a/src/apps/toolbar/modules/Notifications/infra/Notifications.tsx
+++ b/src/apps/toolbar/modules/Notifications/infra/Notifications.tsx
@@ -1,13 +1,16 @@
 import { SeelenCommand } from '@seelen-ui/lib';
-import { invoke } from '@tauri-apps/api/core';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
 import { Button } from 'antd';
 import { AnimatePresence, motion } from 'framer-motion';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 
 import { BackgroundByLayersV2 } from '../../../../seelenweg/components/BackgroundByLayers/infra';
+import { LAZY_CONSTANTS } from '../../shared/utils/infra';
 
 import { Selectors } from '../../shared/store/app';
+
+import { AppNotification } from '../../shared/store/domain';
 
 import { Icon } from '../../../../shared/components/Icon';
 
@@ -37,7 +40,7 @@ export function Notifications() {
 
       <div className="notifications-body">
         <AnimatePresence>
-          {notifications.map((notification) => (
+          {notifications.map((notification: AppNotification) => (
             <motion.div
               className="notification"
               key={notification.id}
@@ -47,7 +50,7 @@ export function Notifications() {
             >
               <div className="notification-header">
                 <div className="notification-header-info">
-                  <Icon iconName="TbNotification" />
+                  <img className="notification-icon" src={convertFileSrc(notification.app_logo ? notification.app_logo : LAZY_CONSTANTS.MISSING_ICON_PATH)} />
                   <div>{notification.app_name}</div>
                   <span>-</span>
                   <div>

--- a/static/themes/default/theme.toolbar.css
+++ b/static/themes/default/theme.toolbar.css
@@ -534,6 +534,10 @@
   color: var(--color-gray-800);
 }
 
+.notification-icon {
+  width: 1.5em;
+}
+
 .notification-body {
   word-break: break-word;
 


### PR DESCRIPTION
This solves the most of the icons of the notifications. 

Here the path were tried: 
- display_info.GetLogo() -> terrible quality and wrong Task implementation on Rust side. The first was solved manually reimplement the task behaviour, but the quality was terrible and did not resolve those which were missing, only whose could be extracted based on umid. 
- Package() not implemented
- ... some which I can not recall :D 

Those which could not be resolved by pure umid, searched based on umid in start menu folder, as seen in weg. 
(I had the same idea and copied from launcher... but seen, you have already extracted that and added umid extraction, I did that based on display name before... so I changed that to your solution)

![image](https://github.com/user-attachments/assets/3e1d7d8f-ad0f-4aaf-ac71-5a28968fcbd7)


There are some app which has aumid, but it does not belongs to anything... 

example: 
- Windows.SystemToast.WiFiNetworkManager