### PR TITLE
fix: resolve #431 issue

### DIFF
--- a/src/apps/settings/i18n/translations/ko.yml
+++ b/src/apps/settings/i18n/translations/ko.yml
@@ -51,7 +51,7 @@ apps_configurations:
     or: 또는
     remove: 블록 삭제
   import: 가져오기
-  new: 새로 만들기
+  new: New
   search: 검색
   swap: 교체
 cancel: 취소

--- a/src/apps/settings/modules/appsConfigurations/infra/index.module.css
+++ b/src/apps/settings/modules/appsConfigurations/infra/index.module.css
@@ -10,7 +10,11 @@
   width: 100%;
   background-color: var(--color-green-600);
   padding: 0;
-
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  
   &:hover {
     background-color: var(--color-green-700) !important;
   }


### PR DESCRIPTION
## Related Issue
- Closes https://github.com/eythaann/Seelen-UI/issues/431
- #432- I'm reposting pr because the commit sign hasn't been signed

## Problem
There was an issue where button text overflowed, causing inconsistent display across different languages or long text scenarios.

## Summary
Fixed an issue with button text overflow by applying CSS changes to ensure all languages are consistently aligned to the left, with any overflowing text hidden. and Korean Term in question has been changed to 'New'.

