### PR TITLE
User awaited indexing instead of technical reality. 

### DIFF
--- a/src/background/seelen_weg/cli.rs
+++ b/src/background/seelen_weg/cli.rs
@@ -36,8 +36,10 @@ impl SeelenWeg {
 
     pub fn process(matches: &clap::ArgMatches) -> Result<()> {
         let subcommand = SubCommand::try_from(matches)?;
-        if let SubCommand::ForegroundOrRunApp(idx) = subcommand {
+        if let SubCommand::ForegroundOrRunApp(index) = subcommand {
             let id = Monitor::from(WindowsApi::monitor_from_cursor_point()).device_id()?;
+            //This shift the user awaited number to the index (when you press 1 you want to open the 0 index, if you press 0, then it is then 10. item which 9 in index)
+            let idx = if index == 0 { 9 } else { index - 1 };
 
             let items = trace_lock!(WEG_ITEMS_IMPL).get_filtered_by_monitor()?;
             if let Some(wegitems) = items.get(&id) {


### PR DESCRIPTION
This is the functionality how the original keys working in windows. 

When you press the number, you await the "number" nth icon to interact with. 

The zero cause of the english keyboard originated function is at the end of the numbers and means 10th. This is how it works in windows at this moment. This is how a user awaits it.  

The line ending is totally fucked up in this file... this is the only modification:
![image](https://github.com/user-attachments/assets/764964ff-4f62-470a-8d03-322e0c65c244)
