### PR TITLE
Fix of fullscreen issue debuging related notices

### DIFF
--- a/src/background/seelen_bar/mod.rs
+++ b/src/background/seelen_bar/mod.rs
@@ -84,7 +84,7 @@ impl FancyToolbar {
                 .contains(&WindowsApi::exe(hwnd).unwrap_or_default().as_str());
 
         let state = FULL_STATE.load();
-        let settings = &state.settings().seelenweg();
+        let settings = &state.settings().fancy_toolbar();
 
         if settings.use_multi_monitor_overlap_logic {
             if is_overlaped {

--- a/src/background/winevent.rs
+++ b/src/background/winevent.rs
@@ -323,9 +323,11 @@ impl WinEvent {
                             }
                         }
                         _ => {
-                            // remove fullscreen of latest when foregrounding another window
+                            // remove fullscreen of latest when foregrounding another window on the same monitor
                             if let Some(old) = latest_fullscreened.take() {
-                                synthetics.push(Self::SyntheticFullscreenEnd(old));
+                                if old.monitor == WindowsApi::monitor_from_window(origin) {
+                                    synthetics.push(Self::SyntheticFullscreenEnd(old));
+                                }
                             }
                             // if new foregrounded window is fullscreen emit it
                             if is_origin_fullscreen {


### PR DESCRIPTION
Fist: 

- TB requests for weg settings which was mistaken. 
- When other window item gets foreground the fullscreen is left from Seelen, but not for the application which is still at fullscreen. This is fixed, only in that case we leave the fullscreen hidden status, if on the monitor the focus is changed to a non fullscreened application. 

Hereby you can see films Seelenless on a screen while work on the other ;) 
