### PR TITLE
Recent folder content & style fix

### DIFF
--- a/static/themes/default/seelen/fancy-toolbar.scss
+++ b/static/themes/default/seelen/fancy-toolbar.scss
@@ -889,7 +889,7 @@
 
       &.userhome-directory-content-open {
         max-height: 200px;
-        overflow: scroll;
+        overflow: auto;
       }
     }
   }


### PR DESCRIPTION
Little dot in the corner cause of enforced overflow: scroll.

The recent folder only can show the lnks