### PR TITLE
Local account, Admin runner user

### DIFF
--- a/src/apps/toolbar/modules/user/infra/UserProfile.tsx
+++ b/src/apps/toolbar/modules/user/infra/UserProfile.tsx
@@ -73,20 +73,22 @@ export function UserProfile({ user }: Props) {
 
         <div className="userhome-profile-email">{user.email}</div>
 
-        <Tooltip
-          mouseLeaveDelay={0}
-          arrow={false}
-          title={t('userhome.profile.open_onedrive')}
-          placement="right"
-        >
-          <button
-            className="userhome-profile-action-button"
-            onClick={() => invoke(SeelenCommand.OpenFile, { path: user.oneDrivePath })}
+        { user.oneDrivePath &&
+          <Tooltip
+            mouseLeaveDelay={0}
+            arrow={false}
+            title={t('userhome.profile.open_onedrive')}
+            placement="right"
           >
-            <Icon iconName="ImOnedrive" />
-            <span>OneDrive</span>
-          </button>
-        </Tooltip>
+            <button
+              className="userhome-profile-action-button"
+              onClick={() => invoke(SeelenCommand.OpenFile, { path: user.oneDrivePath })}
+            >
+              <Icon iconName="ImOnedrive" />
+              <span>OneDrive</span>
+            </button>
+          </Tooltip>
+        }
       </div>
     </div>
   );


### PR DESCRIPTION
Requested: 
https://github.com/eythaann/Seelen-UI/issues/574 

Changed on name determination: (pseudo code)
if admin -> get last logged in user loginUser 
fallback: winapi resolved sam name
if not admin: get winapi display name
fallback: posssible resolve sam name

Changed on image determination:
resolve from configured picture
fallback: windows default user.png