### PR TITLE
Init power mode state handling

### DIFF
--- a/src/background/modules/power/infrastructure.rs
+++ b/src/background/modules/power/infrastructure.rs
@@ -27,8 +27,10 @@ pub fn get_power_status() -> Result<PowerStatus> {
 
 #[tauri::command(async)]
 pub fn get_power_mode() -> Result<PowerMode> {
-    // TODO find a way to get the current power plan
-    Ok(PowerMode::Unknown)
+    Ok(trace_lock!(POWER_MANAGER)
+        .current_power_mode
+        .clone()
+        .unwrap_or(PowerMode::Unknown))
 }
 
 #[tauri::command(async)]


### PR DESCRIPTION
The subscribtion handling this state is: 
https://learn.microsoft.com/en-us/windows/win32/api/powersetting/nf-powersetting-powerregisterforeffectivepowermodenotifications

Which mentions on subscribtion the current value will be imediatelly called on the callback. This value stored on manager and this state will be propagated to get_power_mode, hereby after the init, the state will be saved on the manager immediatelly and can be used for current state requests.