### PR TITLE
Fullscreen app and shared pixel problem resolution

### DIFF
--- a/src/background/utils/mod.rs
+++ b/src/background/utils/mod.rs
@@ -46,7 +46,9 @@ pub fn are_overlaped(a: &RECT, b: &RECT) -> bool {
     if a == &zeroed || b == &zeroed {
         return false;
     }
-    if a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom {
+    // The edge pixel overlapping do not matters. This resolves the shared pixel in between the monitors,
+    // hereby a fullscreened app shared pixel collision does not hide other monitor windows.
+    if a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom {
         return false;
     }
     true


### PR DESCRIPTION
Problem: 
![image](https://github.com/user-attachments/assets/e7659e74-44dd-45db-acdb-a3f2d43cae53)

Solution:
Ignore the 1 px on the edge, so if an app only overlapp the edge 1 px, that does not matter. 