### PR TITLE
Fix incorrect portuguese translation of the word "right"

### DIFF
--- a/src/apps/settings/i18n/translations/pt.yml
+++ b/src/apps/settings/i18n/translations/pt.yml
@@ -156,7 +156,7 @@ shortcuts:
     focus_bottom: Foco Inferior
     focus_latest: Foco mais recente
     focus_left: Foco à esquerda
-    focus_right: Foco certo
+    focus_right: Foco à direita
     focus_top: Foco Superior
     increase_height: Aumentar a altura
     increase_width: Aumentar largura


### PR DESCRIPTION
The word "right" was translated in its "correctness" meaning in the focus settings in Portuguese, AFAIK, it's the only place this happened