### PR TITLE
fix(power): refresh battery state after sleep (#1310)

### DIFF
--- a/src/background/modules/power/domain.rs
+++ b/src/background/modules/power/domain.rs
@@ -28,6 +28,9 @@ pub fn power_mode_to_serializable(mode: EFFECTIVE_POWER_MODE) -> PowerMode {
 }
 
 pub fn battery_to_slu_battery(battery: battery::Battery) -> Result<Battery> {
+
+    battery.refresh()?;
+    
     let percentage = (battery.state_of_charge().value * 100.0).round();
 
     Ok(Battery {


### PR DESCRIPTION
### Summary
Fixes an issue where Seelen UI could show an incorrect (cached) battery
percentage after resuming from sleep until the charger was plugged in.

### Root cause
On Windows, battery information may be stale immediately after sleep.
The battery state was read without forcing a refresh, leading to
incorrect percentages being displayed.

### Solution
- Force-refresh battery data before computing percentage
- Refresh battery state after power resume without blocking the power event handler

### Files changed
- src/background/modules/power/domain.rs
- src/background/modules/power/application.rs

### Notes
Local Rust/MSVC linker issues on Windows prevented running rust-linter and
rust-test locally. CI should validate the build.

Closes #1310
