### PR TITLE
feat(user): add Xbox Gamertag as optional display name source

### DIFF
--- a/libs/core/src/system_state/user.rs
+++ b/libs/core/src/system_state/user.rs
@@ -48,4 +48,5 @@ pub struct User {
     pub email: Option<String>,
     pub one_drive_path: Option<PathBuf>,
     pub profile_picture_path: Option<PathBuf>,
+    pub xbox_gamertag: Option<String>,
 }

--- a/src/background/modules/user/application.rs
+++ b/src/background/modules/user/application.rs
@@ -121,6 +121,13 @@ impl UserManager {
         Ok((email, PathBuf::from(path)))
     }
 
+    fn get_xbox_gamertag() -> Result<String> {
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let settings = hkcu.open_subkey("SOFTWARE\\Microsoft\\XboxLive")?;
+        let gamertag: String = settings.get_value("Gamertag")?;
+        Ok(gamertag)
+    }
+
     fn get_logged_user() -> User {
         let domain = WindowsApi::get_computer_name(ComputerNameDnsDomain).unwrap_or_default();
         let name = WindowsApi::get_username(NameDisplay)
@@ -143,6 +150,7 @@ impl UserManager {
             email: None,
             one_drive_path: None,
             profile_picture_path: None,
+            xbox_gamertag: None,
         };
 
         if let Ok(sid) = Self::get_logged_on_user_sid() {
@@ -153,6 +161,8 @@ impl UserManager {
                 user.one_drive_path = Some(one_drive_path);
             }
         }
+
+        user.xbox_gamertag = Self::get_xbox_gamertag().ok();
 
         user
     }

--- a/src/static/widgets/user/metadata.yml
+++ b/src/static/widgets/user/metadata.yml
@@ -8,5 +8,15 @@ loader: Internal
 preset: Popup
 hidden: true
 lazy: true
+settings:
+  - type: select
+    key: displayNameSource
+    label: Display Name
+    options:
+      - label: Profile Name
+        value: profileName
+      - label: Xbox Gamertag
+        value: xboxGamertag
+    defaultValue: profileName
 plugins:
   - !extend ./toolbar-plugin.yml

--- a/src/static/widgets/user/toolbar-plugin.yml
+++ b/src/static/widgets/user/toolbar-plugin.yml
@@ -8,8 +8,8 @@ plugin:
   scopes:
     - User
   tooltip: |-
-    return user.name;
+    return user.displayName;
   template: |-
-    return [Image({ path: user.profilePicturePath }), ' ', user.name];
+    return [Image({ path: user.profilePicturePath }), ' ', user.displayName];
   onClickV2: |-
     trigger("@seelen/user-menu");

--- a/src/ui/react/toolbar/modules/shared/state/mod.ts
+++ b/src/ui/react/toolbar/modules/shared/state/mod.ts
@@ -11,13 +11,17 @@ export const $settings = signal({
   dateFormat: initialSettings.dateFormat,
   startOfWeek: initialSettings.startOfWeek,
 });
+export const $allByWidget = signal(initialSettings.byWidget);
 Settings.onChange(
-  (settings) => ($settings.value = {
-    ...settings.byWidget["@seelen/fancy-toolbar"],
-    language: settings.language || "en",
-    dateFormat: settings.dateFormat,
-    startOfWeek: settings.startOfWeek,
-  }),
+  (settings) => {
+    $settings.value = {
+      ...settings.byWidget["@seelen/fancy-toolbar"],
+      language: settings.language || "en",
+      dateFormat: settings.dateFormat,
+      startOfWeek: settings.startOfWeek,
+    };
+    $allByWidget.value = settings.byWidget;
+  },
 );
 
 export const $widget_rect = computed(() => {

--- a/src/ui/react/toolbar/modules/shared/state/scope.ts
+++ b/src/ui/react/toolbar/modules/shared/state/scope.ts
@@ -1,11 +1,12 @@
 import { useComputed } from "@preact/signals";
 import { invoke, SeelenCommand } from "@seelen-ui/lib";
 import { ToolbarJsScope } from "@seelen-ui/lib/types";
+import type { WidgetId } from "@seelen-ui/lib/types";
 import { useSyncClockInterval, useThrottle } from "libs/ui/react/utils/hooks";
 import moment from "moment";
 import { useEffect, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
-import { $settings } from "./mod";
+import { $allByWidget, $settings } from "./mod";
 import { $virtual_desktop } from "./system";
 import { $focused } from "./windows";
 import * as globalState from "./global";
@@ -182,9 +183,20 @@ function useKeyboardScope() {
 
 function useUserScope() {
   const user = useComputed(() => globalState.$user.value);
+  const userMenuConfig = useComputed(
+    () => $allByWidget.value?.["@seelen/user-menu" as WidgetId],
+  );
+
+  const displayName = useComputed(() => {
+    const source = (userMenuConfig.value as Record<string, unknown> | undefined)?.displayNameSource;
+    if (source === "xboxGamertag" && user.value?.xboxGamertag) {
+      return user.value.xboxGamertag;
+    }
+    return user.value?.name;
+  });
 
   return {
-    user: user.value,
+    user: { ...user.value, displayName: displayName.value },
   };
 }
 


### PR DESCRIPTION
Adds an optional Xbox Gamertag display name source to the user toolbar widget.

Backend reads the gamertag from `HKCU\SOFTWARE\Microsoft\XboxLive` and exposes it as `xboxGamertag` on the `User` struct. A new `displayNameSource` select setting on the `@seelen/user-menu` widget lets users pick between their profile name (default) and their Xbox Gamertag.

When set to Xbox Gamertag, the toolbar shows the gamertag instead of the profile name. Falls back to profile name if no gamertag is found. Default behavior is unchanged.

6 files changed — User struct, registry read, widget metadata, toolbar state signal, scope builder, toolbar template.