### PR TITLE
Update Turkish translations for UI terms

### DIFF
--- a/src/ui/react/weg/i18n/translations/tr.yml
+++ b/src/ui/react/weg/i18n/translations/tr.yml
@@ -2,8 +2,8 @@ app_menu:
   close: Kapat
   close_multiple: Tümünü Kapat
   copy_handles: Tanıtıcıları Kopyala
-  kill: Süreci Sonlandır
-  kill_multiple: Tüm Süreçleri Öldür
+  kill: Görevi Sonlandır
+  kill_multiple: Tüm Görevleri Sonlandır
   open_file_location: Dosya Konumunu Aç
   pin: Sabitle
   pin_to_center: Ortaya Sabitle
@@ -16,7 +16,7 @@ context_menu:
   reorder_disable: Görev çubuğunu kilitle
   reorder_enable: Görev çubuğunun kilidini aç
 media:
-  not_playing: Hiçbir şey oynamıyor
+  not_playing: Medya oynatılmıyor
 show_desktop:
   label: Masaüstünü Göster
 start:


### PR DESCRIPTION
Update Turkish translations for process and media terms

app_menu:

Kill: Süreci Sonlandır (not right term)
Kill: Görevi Sonlandır 
Kill_multiple: Tüm Süreçleri Sonlandır (not right term)
Kill_ multiple: Tüm Görevleri Sonlandır (new)


media: 

not_playing: Hiç bir şey oynamıyor (old)
not_playing: Medya oynatılmıyor (new)

Improved Turkish translations to make them more natural and aligned with the common phrasing Turkish Windows users are familiar with. @eythaann 