### PR TITLE
chore: npm audit fix (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@nyariv/sandboxjs": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@nyariv/sandboxjs/-/sandboxjs-0.9.4.tgz",
-      "integrity": "sha512-c0rqf8+wcd1rt6usW12aMPnj//Q6fIdxRQOcclUxrd0mumz/apxqFZBT2ztw10n8jQpwlZ2R76pjIlnZbodadw==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@nyariv/sandboxjs/-/sandboxjs-0.9.6.tgz",
+      "integrity": "sha512-KoYu1SHo1ymfpFN0i5UmMcOLmifpS80CHElXMklMA9po1EiEQLzEENgobXUiowM7wnqHJ33EIFQN2P2Z5cljyQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2718,13 +2718,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -3569,9 +3569,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Automated low-risk security maintenance: ran `npm audit fix --package-lock-only` (no scripts).

- Changes: update `package-lock.json` only
- Goal: reduce known vulnerable transitive deps where possible