### PR TITLE
fix(widgets): avoid drag activation on touchpad tap

### DIFF
--- a/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
+++ b/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
-import { KeyboardSensor, PointerSensor } from "@dnd-kit/dom";
+import { KeyboardSensor, PointerActivationConstraints, PointerSensor } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
 import { invoke, SeelenCommand } from "@seelen-ui/lib";
 import { cx } from "libs/ui/react/utils/styling.ts";
@@ -23,12 +23,19 @@ import { useMainContextMenu } from "./ContextMenu.tsx";
 import { matchIds } from "../shared/utils.ts";
 import { useComputed } from "@preact/signals";
 
-// Allow dragging from buttons and other interactive elements inside items.
-// The distance activation constraint (5px) still prevents unintentional drags on click.
 const dndSensors = [
-  PointerSensor.configure({ preventActivation: () => false }),
+  PointerSensor.configure({
+    preventActivation: () => false,
+    activationConstraints: [
+      new PointerActivationConstraints.Distance({ value: 24 }),
+    ],
+  }),
   KeyboardSensor,
 ];
+
+function hasSameOrder(a: string[], b: string[]) {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
 
 export function FancyToolbar() {
   const splittedItems = useComputed(() => {
@@ -76,10 +83,12 @@ export function FancyToolbar() {
           const temp = $toolbar_state.value.items.map((item) => typeof item === "string" ? item : item.id);
           const newItems = move(temp, event);
 
-          $toolbar_state.value = {
-            isReorderDisabled: $toolbar_state.value.isReorderDisabled,
-            items: newItems.map((id) => $toolbar_state.value.items.find((i) => matchIds(i, id))!),
-          };
+          if (!hasSameOrder(temp, newItems)) {
+            $toolbar_state.value = {
+              isReorderDisabled: $toolbar_state.value.isReorderDisabled,
+              items: newItems.map((id) => $toolbar_state.value.items.find((i) => matchIds(i, id))!),
+            };
+          }
         }}
       >
         <Group id="left" items={splittedItems.value.left} startIndex={0} />

--- a/src/ui/react/weg/modules/bar/ItemReordableList.tsx
+++ b/src/ui/react/weg/modules/bar/ItemReordableList.tsx
@@ -1,4 +1,5 @@
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { KeyboardSensor, PointerActivationConstraints, PointerSensor } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
 import { WegItemType, WegPinnedItemsVisibility, WegTemporalItemsVisibility } from "@seelen-ui/lib/types";
 import { useTranslation } from "react-i18next";
@@ -45,6 +46,20 @@ const visibleItems = computed(() => {
   });
 });
 
+const dndSensors = [
+  PointerSensor.configure({
+    preventActivation: () => false,
+    activationConstraints: [
+      new PointerActivationConstraints.Distance({ value: 24 }),
+    ],
+  }),
+  KeyboardSensor,
+];
+
+function hasSameOrder(a: SwItem[], b: SwItem[]) {
+  return a.length === b.length && a.every((item, index) => item.id === b[index]?.id);
+}
+
 export function DockItems() {
   const { t } = useTranslation();
 
@@ -52,9 +67,13 @@ export function DockItems() {
 
   return (
     <DragDropProvider
+      sensors={dndSensors}
       onDragOver={(event) => {
-        const newItems = move($dock_state.value.items, event);
-        $dock_state.value = { ...$dock_state.value, items: newItems };
+        const currentItems = $dock_state.value.items;
+        const newItems = move(currentItems, event);
+        if (!hasSameOrder(currentItems, newItems)) {
+          $dock_state.value = { ...$dock_state.value, items: newItems };
+        }
       }}
     >
       <div className="weg-items">

--- a/src/ui/react/weg/modules/item/infra/StartMenu.tsx
+++ b/src/ui/react/weg/modules/item/infra/StartMenu.tsx
@@ -35,7 +35,10 @@ export const StartMenu = memo(({ item }: Props) => {
   return (
     <div
       className="weg-item weg-item-start"
-      onClick={() => {
+      onPointerDown={(event) => {
+        if (event.button !== 0) {
+          return;
+        }
         if (!isStartMenuOpen) {
           invoke(SeelenCommand.ShowStartMenu);
         }


### PR DESCRIPTION
## Summary

This PR fixes a touchpad tap interaction issue on the dock and toolbar.

On my Windows on ARM device, an ASUS Zenbook SORA 16 UX3607OA, tapping dock items with the touchpad can produce a tiny pointer movement. The current drag/drop behavior may treat that tap as a reorder gesture, causing dock state to be saved and preventing the intended click interaction.

The implementation, local checks, signed commit, push, and PR preparation were completed with Codex automation under my instruction. I am not experienced with code, but I manually tested this build on the affected device and have not found issues so far.

I submit this contribution under the project's CLA and AGPLv3 license. Maintainers are welcome to modify, adapt, simplify, or integrate the changes in whatever way best fits the project.

## Changes

- Add a 24px pointer distance activation constraint for dock and toolbar reordering.
- Avoid writing dock/toolbar state when the order did not actually change.
- Trigger the dock Start Menu item on left pointerdown so the apps menu toggle runs before focus-loss hiding can reopen it.

## Why this works

The issue appears to be caused by touchpad taps creating very small pointer movement. Without a distance activation threshold, the drag/drop system can interpret that movement as a drag start. That causes reorder state handling to run during what should be a simple tap.

By requiring 24px of movement before drag activation, normal touchpad taps continue as clicks, while intentional drag/reorder gestures still work. The same-order guard prevents unnecessary state writes when no actual item reorder happened.

The Start Menu adjustment handles a related timing issue: when the apps menu is already open, clicking the dock Start Menu button can first trigger focus-loss hiding and then immediately re-trigger opening. Handling the left pointerdown earlier lets the existing toggle behavior run before the focus-loss hide path can reopen it.

## Tested

Device:

- ASUS Zenbook SORA 16 UX3607OA
- Snapdragon X2 Elite Extreme / ARM64
- Windows 11 Home 10.0.28000

Manual testing:

- Touchpad tap on dock app icons opens apps reliably.
- Touchpad tap no longer appears to save dock state unless a real reorder happens.
- Start Menu button can open and close the apps menu.

Local checks:

- `npm run build:ui -- --production`
- `deno fmt --check`
- `deno lint`
- `npm run type-check`
