### PR TITLE
[codex] Fix touchpad tap handling for widgets

### DIFF
--- a/libs/core/src/state/widget/interfaces.ts
+++ b/libs/core/src/state/widget/interfaces.ts
@@ -61,6 +61,15 @@ export interface InitWidgetOptions {
   hideOnFocusLoss?: boolean;
 
   /**
+   * Hides the widget when it is triggered while already visible.
+   *
+   * Intended for toolbar popups whose button should behave as an open/close toggle.
+   *
+   * @default false
+   */
+  toggleOnTrigger?: boolean;
+
+  /**
    * Closes the widget after being hidden for a period of time,
    * instead of keeping it in memory.
    *

--- a/libs/core/src/state/widget/mod.ts
+++ b/libs/core/src/state/widget/mod.ts
@@ -28,6 +28,7 @@ interface WidgetInternalState {
   initialized: boolean;
   ready: boolean;
   firstFocus: boolean;
+  lastFocusLossHideAt: number;
 }
 
 /**
@@ -71,6 +72,7 @@ export class Widget {
     initialized: false,
     ready: false,
     firstFocus: true,
+    lastFocusLossHideAt: 0,
   };
 
   private constructor(widget: IWidget) {
@@ -112,8 +114,16 @@ export class Widget {
   private applyOverlayPreset(): void {}
 
   /** Will apply the recommended settings for a popup widget */
-  private applyPopupPreset(): void {
+  private applyPopupPreset(toggleOnTrigger: boolean): void {
     this.onTrigger(async ({ desiredPosition, alignX, alignY }) => {
+      if (toggleOnTrigger) {
+        const recentlyHiddenByFocusLoss = Date.now() - this.runtimeState.lastFocusLossHideAt < 300;
+        if ((await this.window.isVisible()) || recentlyHiddenByFocusLoss) {
+          this.hide();
+          return;
+        }
+      }
+
       if (desiredPosition) {
         await this.adjustAndSetPosition(desiredPosition.x, desiredPosition.y, alignX, alignY);
       }
@@ -133,6 +143,7 @@ export class Widget {
     let wasFocused = false;
 
     const hideDelayed = debounce(() => {
+      this.runtimeState.lastFocusLossHideAt = Date.now();
       this.hide();
     }, 100);
 
@@ -252,7 +263,7 @@ export class Widget {
         this.applyOverlayPreset();
         break;
       case WidgetPreset.Popup:
-        this.applyPopupPreset();
+        this.applyPopupPreset(options.toggleOnTrigger ?? false);
         break;
     }
 

--- a/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
+++ b/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
@@ -23,11 +23,13 @@ import { useMainContextMenu } from "./ContextMenu.tsx";
 import { matchIds } from "../shared/utils.ts";
 import { useComputed } from "@preact/signals";
 
+const DND_ACTIVATION_DISTANCE = 24;
+
 const dndSensors = [
   PointerSensor.configure({
     preventActivation: () => false,
     activationConstraints: [
-      new PointerActivationConstraints.Distance({ value: 24 }),
+      new PointerActivationConstraints.Distance({ value: DND_ACTIVATION_DISTANCE }),
     ],
   }),
   KeyboardSensor,

--- a/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
+++ b/src/ui/react/fancy-toolbar/modules/main/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
-import { KeyboardSensor, PointerSensor } from "@dnd-kit/dom";
+import { KeyboardSensor, PointerActivationConstraints, PointerSensor } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
 import { invoke, SeelenCommand } from "@seelen-ui/lib";
 import { cx } from "libs/ui/react/utils/styling.ts";
@@ -23,12 +23,19 @@ import { useMainContextMenu } from "./ContextMenu.tsx";
 import { matchIds } from "../shared/utils.ts";
 import { useComputed } from "@preact/signals";
 
-// Allow dragging from buttons and other interactive elements inside items.
-// The distance activation constraint (5px) still prevents unintentional drags on click.
 const dndSensors = [
-  PointerSensor.configure({ preventActivation: () => false }),
+  PointerSensor.configure({
+    preventActivation: () => false,
+    activationConstraints: [
+      new PointerActivationConstraints.Distance({ value: 24 }),
+    ],
+  }),
   KeyboardSensor,
 ];
+
+function hasSameOrder(a: string[], b: string[]) {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
 
 export function FancyToolbar() {
   const splittedItems = useComputed(() => {
@@ -76,10 +83,12 @@ export function FancyToolbar() {
           const temp = $toolbar_state.value.items.map((item) => typeof item === "string" ? item : item.id);
           const newItems = move(temp, event);
 
-          $toolbar_state.value = {
-            isReorderDisabled: $toolbar_state.value.isReorderDisabled,
-            items: newItems.map((id) => $toolbar_state.value.items.find((i) => matchIds(i, id))!),
-          };
+          if (!hasSameOrder(temp, newItems)) {
+            $toolbar_state.value = {
+              isReorderDisabled: $toolbar_state.value.isReorderDisabled,
+              items: newItems.map((id) => $toolbar_state.value.items.find((i) => matchIds(i, id))!),
+            };
+          }
         }}
       >
         <Group id="left" items={splittedItems.value.left} startIndex={0} />

--- a/src/ui/react/weg/modules/bar/ItemReordableList.tsx
+++ b/src/ui/react/weg/modules/bar/ItemReordableList.tsx
@@ -1,4 +1,5 @@
 import { DragDropProvider, DragOverlay } from "@dnd-kit/react";
+import { KeyboardSensor, PointerActivationConstraints, PointerSensor } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
 import { WegItemType, WegPinnedItemsVisibility, WegTemporalItemsVisibility } from "@seelen-ui/lib/types";
 import { useTranslation } from "react-i18next";
@@ -45,6 +46,20 @@ const visibleItems = computed(() => {
   });
 });
 
+const dndSensors = [
+  PointerSensor.configure({
+    preventActivation: () => false,
+    activationConstraints: [
+      new PointerActivationConstraints.Distance({ value: 24 }),
+    ],
+  }),
+  KeyboardSensor,
+];
+
+function hasSameOrder(a: SwItem[], b: SwItem[]) {
+  return a.length === b.length && a.every((item, index) => item.id === b[index]?.id);
+}
+
 export function DockItems() {
   const { t } = useTranslation();
 
@@ -52,9 +67,13 @@ export function DockItems() {
 
   return (
     <DragDropProvider
+      sensors={dndSensors}
       onDragOver={(event) => {
-        const newItems = move($dock_state.value.items, event);
-        $dock_state.value = { ...$dock_state.value, items: newItems };
+        const currentItems = $dock_state.value.items;
+        const newItems = move(currentItems, event);
+        if (!hasSameOrder(currentItems, newItems)) {
+          $dock_state.value = { ...$dock_state.value, items: newItems };
+        }
       }}
     >
       <div className="weg-items">

--- a/src/ui/react/weg/modules/bar/ItemReordableList.tsx
+++ b/src/ui/react/weg/modules/bar/ItemReordableList.tsx
@@ -46,11 +46,13 @@ const visibleItems = computed(() => {
   });
 });
 
+const DND_ACTIVATION_DISTANCE = 24;
+
 const dndSensors = [
   PointerSensor.configure({
     preventActivation: () => false,
     activationConstraints: [
-      new PointerActivationConstraints.Distance({ value: 24 }),
+      new PointerActivationConstraints.Distance({ value: DND_ACTIVATION_DISTANCE }),
     ],
   }),
   KeyboardSensor,

--- a/src/ui/react/weg/modules/item/infra/StartMenu.tsx
+++ b/src/ui/react/weg/modules/item/infra/StartMenu.tsx
@@ -7,18 +7,13 @@ import type { StartMenuWegItem } from "../../shared/types.ts";
 
 import { $settings, getDockContextMenuAlignment } from "../../shared/state/settings.ts";
 import { getMenuForItem } from "./GeneralMenu.tsx";
-import { $delayedFocused } from "../../shared/state/windows.ts";
 
 interface Props {
   item: StartMenuWegItem;
 }
 
-const startMenuExes = ["SearchHost.exe", "StartMenuExperienceHost.exe"];
-
 export const StartMenu = memo(({ item }: Props) => {
   const { t } = useTranslation();
-
-  const isStartMenuOpen = startMenuExes.some((program) => ($delayedFocused.value?.exe || "").endsWith(program));
 
   const onContextMenu = useCallback(
     (e: MouseEvent) => {
@@ -39,9 +34,8 @@ export const StartMenu = memo(({ item }: Props) => {
         if (event.button !== 0) {
           return;
         }
-        if (!isStartMenuOpen) {
-          invoke(SeelenCommand.ShowStartMenu);
-        }
+
+        invoke(SeelenCommand.ShowStartMenu);
       }}
       onContextMenu={onContextMenu}
     >

--- a/src/ui/react/weg/modules/item/infra/StartMenu.tsx
+++ b/src/ui/react/weg/modules/item/infra/StartMenu.tsx
@@ -35,7 +35,10 @@ export const StartMenu = memo(({ item }: Props) => {
   return (
     <div
       className="weg-item weg-item-start"
-      onClick={() => {
+      onPointerDown={(event) => {
+        if (event.button !== 0) {
+          return;
+        }
         if (!isStartMenuOpen) {
           invoke(SeelenCommand.ShowStartMenu);
         }

--- a/src/ui/svelte/apps-menu/components/FolderModal.svelte
+++ b/src/ui/svelte/apps-menu/components/FolderModal.svelte
@@ -5,6 +5,7 @@
   import { DragDropProvider } from "@dnd-kit/svelte";
   import SortableAppItem from "./SortableAppItem.svelte";
   import { arrayMove } from "../utils";
+  import { startMenuDndSensors } from "./dnd";
 
   interface Props {
     folder: FavFolderItem;
@@ -35,6 +36,7 @@
   onclose={onClose}
 >
   <DragDropProvider
+    sensors={startMenuDndSensors}
     onDragOver={(event) => {
       const { source, target } = event.operation;
       if (!source || !target || source.id === target.id) {

--- a/src/ui/svelte/apps-menu/components/PinnedView.svelte
+++ b/src/ui/svelte/apps-menu/components/PinnedView.svelte
@@ -6,6 +6,7 @@
   import { arrayMove } from "../utils";
   import { DragDropProvider } from "@dnd-kit/svelte";
   import { debounce } from "lodash";
+  import { startMenuDndSensors } from "./dnd";
 
   type UniqueIdentifier = string | number;
 
@@ -28,6 +29,7 @@
 <div class="pinned-view">
   <div class="pinned-view-list">
     <DragDropProvider
+      sensors={startMenuDndSensors}
       onDragMove={(event) => {
         const { source, target } = event.operation;
 

--- a/src/ui/svelte/apps-menu/components/dnd.ts
+++ b/src/ui/svelte/apps-menu/components/dnd.ts
@@ -1,0 +1,13 @@
+import { KeyboardSensor, PointerActivationConstraints, PointerSensor } from "@dnd-kit/dom";
+
+const DND_ACTIVATION_DISTANCE = 24;
+
+export const startMenuDndSensors = [
+  PointerSensor.configure({
+    preventActivation: () => false,
+    activationConstraints: [
+      new PointerActivationConstraints.Distance({ value: DND_ACTIVATION_DISTANCE }),
+    ],
+  }),
+  KeyboardSensor,
+];

--- a/src/ui/svelte/apps-menu/index.ts
+++ b/src/ui/svelte/apps-menu/index.ts
@@ -13,9 +13,17 @@ const widget = Widget.getCurrent();
 
 await widget.init({ hideOnFocusLoss: true });
 
+let lastFocusLossAt = 0;
+widget.window.onFocusChanged(({ payload: focused }) => {
+  if (!focused) {
+    lastFocusLossAt = Date.now();
+  }
+});
+
 widget.onTrigger(async (args) => {
   const visible = await widget.window.isVisible();
-  if (visible) {
+  const recentlyHiddenByFocusLoss = Date.now() - lastFocusLossAt < 300;
+  if (visible || recentlyHiddenByFocusLoss) {
     widget.hide();
   } else {
     onTriggered(args.monitorId);

--- a/src/ui/svelte/bluetooth-popup/index.ts
+++ b/src/ui/svelte/bluetooth-popup/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/calendar-popup/index.ts
+++ b/src/ui/svelte/calendar-popup/index.ts
@@ -11,6 +11,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/keyboard-selector/index.ts
+++ b/src/ui/svelte/keyboard-selector/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/media-popup/index.ts
+++ b/src/ui/svelte/media-popup/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/network-popup/index.ts
+++ b/src/ui/svelte/network-popup/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/notifications/index.ts
+++ b/src/ui/svelte/notifications/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();

--- a/src/ui/svelte/power-menu/index.ts
+++ b/src/ui/svelte/power-menu/index.ts
@@ -9,7 +9,20 @@ import "@seelen-ui/lib/styles/reset.css";
 await loadTranslations();
 
 const widget = Widget.getCurrent();
+let lastFocusLossAt = 0;
+widget.window.onFocusChanged(({ payload: focused }) => {
+  if (!focused) {
+    lastFocusLossAt = Date.now();
+  }
+});
+
 widget.onTrigger(async () => {
+  const recentlyHiddenByFocusLoss = Date.now() - lastFocusLossAt < 300;
+  if ((await widget.window.isVisible()) || recentlyHiddenByFocusLoss) {
+    widget.hide();
+    return;
+  }
+
   await widget.show();
   await widget.focus();
 });

--- a/src/ui/svelte/quick-settings/index.ts
+++ b/src/ui/svelte/quick-settings/index.ts
@@ -12,6 +12,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 mount(App, {

--- a/src/ui/svelte/system-tray/index.ts
+++ b/src/ui/svelte/system-tray/index.ts
@@ -9,6 +9,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 mount(App, {

--- a/src/ui/svelte/user-menu/index.ts
+++ b/src/ui/svelte/user-menu/index.ts
@@ -10,6 +10,7 @@ const root = document.getElementById("root")!;
 const widget = Widget.getCurrent();
 await widget.init({
   autoSizeByContent: root,
+  toggleOnTrigger: true,
 });
 
 await loadTranslations();


### PR DESCRIPTION
## Summary

This PR contains two related but independent fixes for touchpad tap handling.

### Patch 1: Avoid treating touchpad taps as drag gestures

Some touchpad taps can include a small pointer movement. With the default `@dnd-kit` pointer activation distance, this can be interpreted as a drag instead of a click.

This patch adds a 24px drag activation distance for:

- Dock item reordering
- Fancy toolbar item reordering
- Apps menu pinned items
- Apps menu folder modal items

The threshold is kept as a named constant so maintainers can tune it easily if needed.

### Patch 2: Let popup/menu buttons close on second trigger

Some popup widgets could open on the first click/tap but fail to close on the second one, especially when focus loss and trigger events happened close together.

This patch adds an optional `toggleOnTrigger` popup behavior and applies it to toolbar popups. It also updates the apps menu and power menu trigger handling so a repeated trigger hides the already-open widget instead of reopening it after focus loss.

## Testing

Built and manually tested on:

- Device: ASUS Zenbook SORA 16 UX3607OA
- OS: Windows 11 on ARM64

Manual testing covered:

- Touchpad tap on dock icons
- Touchpad tap on toolbar items
- Touchpad tap inside the apps menu pinned area
- Repeated click/tap to open and close popup menus

No issue was found during simple human testing.

Automated/local checks run:

- `git diff --check`
- `npm run type-check`
- `npm run build:ui`

## Note

The code changes, local build, deployment, and PR preparation were performed by Codex on behalf of the user. The user does not have coding experience, but did perform simple real-device testing.

This contribution is submitted under the repository's existing license. Maintainers are welcome to modify, split, rewrite, or adapt any part of the changes as needed.
