### PR TITLE
fix(widgets): evict per-monitor widgets when a display is disconnected

### DIFF
--- a/src/background/app.rs
+++ b/src/background/app.rs
@@ -11,6 +11,7 @@ use crate::{
     error::{Result, ResultLogExt},
     hook::register_win_hook,
     migrations::Migrations,
+    modules::monitors::{MonitorManager, MonitorManagerEvent},
     modules::user::infrastructure::reemit_user,
     resources::RESOURCES,
     session::infrastructure::reemit_session,
@@ -91,6 +92,19 @@ impl SeelenUI {
 
         WIDGET_MANAGER.reconcile()?;
         CRONOMETER.record("reconcile");
+
+        // Re-evaluate per-monitor widgets (toolbar, weg, ...) when a display is
+        // connected or disconnected. Without this, a removed monitor's widgets are
+        // never evicted and Windows relocates their webviews onto a surviving
+        // monitor, stacking them over that monitor's own bars.
+        MonitorManager::subscribe(|event| {
+            if matches!(
+                event,
+                MonitorManagerEvent::ViewAdded(_) | MonitorManagerEvent::ViewRemoved(_)
+            ) {
+                WIDGET_MANAGER.reconcile().log_error();
+            }
+        });
 
         create_background_window()?;
         CRONOMETER.record("background_window");

--- a/src/background/modules/monitors/application.rs
+++ b/src/background/modules/monitors/application.rs
@@ -202,18 +202,26 @@ impl MonitorManager {
         let mut old_views = Self::instance().state_views.to_hash_map();
 
         // new monitors were added
+        let mut added = Vec::new();
         for id in current_views.keys() {
             if old_views.remove(id).is_none() {
-                Self::send(MonitorManagerEvent::ViewAdded(id.clone()));
+                added.push(id.clone());
             }
         }
+        // whatever remains in old_views was removed/disconnected
+        let removed: Vec<MonitorId> = old_views.into_keys().collect();
 
-        // residuals were removed/disconnected
-        for (id, _) in old_views {
+        // Update the cache BEFORE notifying subscribers so anything that reacts to
+        // these events (e.g. widget reconcile) observes the new set of monitors via
+        // get_cached_ids() instead of the stale one.
+        Self::instance().state_views.replace(current_views);
+
+        for id in added {
+            Self::send(MonitorManagerEvent::ViewAdded(id));
+        }
+        for id in removed {
             Self::send(MonitorManagerEvent::ViewRemoved(id));
         }
-
-        Self::instance().state_views.replace(current_views);
         Ok(())
     }
 

--- a/src/background/widgets/loader.rs
+++ b/src/background/widgets/loader.rs
@@ -93,11 +93,13 @@ impl WidgetDeployment {
             }
             WidgetInstanceMode::ReplicaByMonitor => {
                 let configs = FULL_STATE.load();
+                let connected = MonitorManager::instance().get_cached_ids();
 
-                // Remove disabled instances
+                // Remove disabled instances and instances whose monitor was disconnected.
                 self.pods.retain(|(label, _)| {
                     let monitor_id = label.monitor_id.as_ref().expect("Missing monitor id");
-                    configs.is_widget_enable_on_monitor(&self.definition.id, monitor_id)
+                    connected.contains(monitor_id)
+                        && configs.is_widget_enable_on_monitor(&self.definition.id, monitor_id)
                 });
 
                 // Add new/enabled instances


### PR DESCRIPTION
On multi-monitor setups, turning off one monitor left that monitor's per-monitor widgets (toolbar / weg) alive. Windows then relocated their webviews onto a surviving monitor, stacking them over that monitor's own bars. Restarting Seelen UI or reconnecting the display cleared it.

Root cause: nothing re-ran the widget reconcile on monitor connect/disconnect, and the ReplicaByMonitor reconcile only checked the user config (is_widget_enable_on_monitor), never whether the monitor was still physically present. It also read a monitor cache that was updated only after the change events were dispatched.

Fixes:
- app: reconcile widgets on MonitorManagerEvent::ViewAdded/ViewRemoved.
- loader: drop ReplicaByMonitor pods whose monitor is no longer in MonitorManager cached ids (dropping the pod destroys its webview).
- monitors: replace the view cache before emitting Added/Removed so subscribers observe the fresh set via get_cached_ids().