### PR TITLE
fix(virtual-desktops): stop windows flashing when switching workspaces

### DIFF
--- a/src/background/virtual_desktops/mod.rs
+++ b/src/background/virtual_desktops/mod.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 use seelen_core::state::{DesktopWorkspace, VirtualDesktopMonitor, VirtualDesktops, WorkspaceId};
 use seelen_core::system_state::MonitorId;
 use slu_utils::{debounce, Debounce};
-use windows::Win32::UI::WindowsAndMessaging::{SW_FORCEMINIMIZE, SW_MINIMIZE, SW_RESTORE};
+use windows::Win32::UI::WindowsAndMessaging::{SW_FORCEMINIMIZE, SW_MINIMIZE, SW_SHOWNOACTIVATE};
 
 use crate::error::{Result, ResultLogExt};
 use crate::event_manager;
@@ -523,12 +523,16 @@ impl DesktopWorkspaceExt for DesktopWorkspace {
                 // Push before show_window to avoid a race where SystemMinimizeEnd
                 // fires on the hook thread before this thread reaches the push.
                 RESTORED_EVENT_QUEUE.push(*addr);
-                // use normal show instead async cuz it will keep the order of restoring
-                window.show_window(SW_RESTORE).log_error();
+                // Restore WITHOUT activating. SW_RESTORE activates each window, so a
+                // workspace with N windows steals foreground N times in a row, which
+                // shows up as rapid flashing (worse the more windows there are). Only
+                // the topmost window is activated, via focus() below.
+                // Sync (not async) show keeps the restore order.
+                window.show_window(SW_SHOWNOACTIVATE).log_error();
             }
             MINIMIZED_BY_WORKSPACES.remove(addr);
 
-            // ensure correct focus
+            // ensure correct focus on the topmost window only
             if idx == len - 1 {
                 window.focus().log_error();
             }

--- a/src/background/virtual_desktops/mod.rs
+++ b/src/background/virtual_desktops/mod.rs
@@ -509,8 +509,11 @@ impl DesktopWorkspaceExt for DesktopWorkspace {
     }
 
     fn restore(&self) {
-        let len = self.windows.len();
-        for (idx, addr) in self.windows.iter().enumerate() {
+        // self.windows is kept in focus order (SystemForeground pushes the focused
+        // window to the end), so the last window that ends up visible is the topmost
+        // one and the only one that should be activated.
+        let mut topmost: Option<isize> = None;
+        for addr in self.windows.iter() {
             let window = Window::from(*addr);
             let is_minimized = window.is_minimized();
 
@@ -532,10 +535,14 @@ impl DesktopWorkspaceExt for DesktopWorkspace {
             }
             MINIMIZED_BY_WORKSPACES.remove(addr);
 
-            // ensure correct focus on the topmost window only
-            if idx == len - 1 {
-                window.focus().log_error();
-            }
+            // this window is now visible; remember it as the current topmost candidate
+            topmost = Some(*addr);
+        }
+
+        // Focus only the topmost visible window. If every window stayed minimized
+        // (nothing was restored), don't force anything to the foreground.
+        if let Some(addr) = topmost {
+            Window::from(addr).focus().log_error();
         }
     }
 }


### PR DESCRIPTION
## Problem
Switching to a workspace that has several windows makes them flash rapidly (worse the more windows the workspace holds).

## Cause
Each window was restored with `SW_RESTORE`, which activates the window, so a workspace with N windows steals the foreground N times in a row.

## Change
- Restore windows with `SW_SHOWNOACTIVATE` and activate only the topmost window.
- Track the last window that actually becomes visible and focus only that one; if every window stays minimized, don't force any window to the foreground.