### PR TITLE
fix(apps-menu): open on the monitor under the cursor, not primary

### DIFF
--- a/src/ui/svelte/apps-menu/index.ts
+++ b/src/ui/svelte/apps-menu/index.ts
@@ -16,7 +16,7 @@ widget.onTrigger(async (args) => {
   if (visible) {
     widget.hide();
   } else {
-    onTriggered(args.monitorId);
+    onTriggered(args.monitorId, args.desiredPosition);
   }
 });
 

--- a/src/ui/svelte/apps-menu/state/mod.svelte.ts
+++ b/src/ui/svelte/apps-menu/state/mod.svelte.ts
@@ -274,6 +274,7 @@ class State {
   disbandFolder = disbandFolder;
 
   desiredMonitorId = $state<string | null>(null);
+  desiredPosition = $state<{ x: number; y: number } | null>(null);
 
   view = $state(StartView.Favorites);
   preselectedItem = $state<string | null>(null);

--- a/src/ui/svelte/apps-menu/state/positioning.svelte.ts
+++ b/src/ui/svelte/apps-menu/state/positioning.svelte.ts
@@ -10,6 +10,14 @@ let monitorToShow = $derived.by(() => {
     targetMonitor = globalState.monitors.find((m) => m.id === globalState.desiredMonitorId);
   }
 
+  // No explicit monitor: use the one under the requested point (mouse cursor).
+  if (!targetMonitor && globalState.desiredPosition) {
+    const p = globalState.desiredPosition;
+    targetMonitor = globalState.monitors.find((m) =>
+      p.x >= m.rect.left && p.x < m.rect.right && p.y >= m.rect.top && p.y < m.rect.bottom
+    );
+  }
+
   // Fallback to primary monitor if not found or not specified
   if (!targetMonitor) {
     targetMonitor = globalState.monitors.find((m) => m.isPrimary) || globalState.monitors[0];
@@ -57,9 +65,13 @@ $effect.root(() => {
   });
 });
 
-export async function onTriggered(monitorId?: string | null) {
+export async function onTriggered(
+  monitorId?: string | null,
+  position?: { x: number; y: number } | null,
+) {
   globalState.view = StartView.Favorites;
   globalState.desiredMonitorId = monitorId || null;
+  globalState.desiredPosition = position || null;
   globalState.version++; // trigger reactive updates
 
   await Widget.self.show();


### PR DESCRIPTION
The apps menu is a Single-instance widget, so its trigger payload carries no monitorId and the positioning code fell back to the primary monitor. The backend already fills desiredPosition with the cursor point on trigger, so use it: when no monitorId is given, pick the monitor that contains that point, and only fall back to primary if neither is available.