### PR TITLE
feat(weg): option to auto-hide each monitor's dock independently

### DIFF
--- a/libs/core/src/state/settings/mod.rs
+++ b/libs/core/src/state/settings/mod.rs
@@ -157,6 +157,11 @@ pub struct SeelenWegSettings {
     pub mode: SeelenWegMode,
     /// When to hide the dock
     pub hide_mode: HideMode,
+    /// When enabled, each monitor's dock decides its auto-hide from the topmost
+    /// window on its own monitor. When disabled (default, original behavior), the
+    /// overlap is derived from the globally focused window, so only the focused
+    /// monitor's dock reacts.
+    pub per_monitor_auto_hide: bool,
     /// Split windows into separated items instead of grouped.
     pub split_windows: bool,
     /// Which temporal items to show on the dock instance (this can be overridden per monitor)
@@ -198,6 +203,7 @@ impl Default for SeelenWegSettings {
             shortcuts: None,
             mode: SeelenWegMode::MinContent,
             hide_mode: HideMode::OnOverlap,
+            per_monitor_auto_hide: false,
             position: SeelenWegSide::Bottom,
             visible_separators: true,
             show_instance_counter: true,

--- a/src/ui/react/settings/i18n/translations/en.yml
+++ b/src/ui/react/settings/i18n/translations/en.yml
@@ -362,7 +362,7 @@ wall:
 weg:
   auto_hide: Auto Hide
   auto_hide_touch_disabled: Auto hide is not available on touch screen devices
-  per_monitor_auto_hide: Auto hide each monitor's dock independently
+  per_monitor_auto_hide: Hide each screen's dock independently
   delay_to_hide: Delay to hide
   delay_to_show: Delay to show
   dock_side: Position

--- a/src/ui/react/settings/i18n/translations/en.yml
+++ b/src/ui/react/settings/i18n/translations/en.yml
@@ -362,6 +362,7 @@ wall:
 weg:
   auto_hide: Auto Hide
   auto_hide_touch_disabled: Auto hide is not available on touch screen devices
+  per_monitor_auto_hide: Auto hide each monitor's dock independently
   delay_to_hide: Delay to hide
   delay_to_show: Delay to show
   dock_side: Position

--- a/src/ui/react/settings/i18n/translations/ja.yml
+++ b/src/ui/react/settings/i18n/translations/ja.yml
@@ -340,6 +340,7 @@ wall:
 weg:
   auto_hide: 自動的に隠す
   auto_hide_touch_disabled: 自動非表示はタッチ スクリーン デバイスでは利用できません
+  per_monitor_auto_hide: モニターごとにドックを個別に隠す
   delay_to_hide: 隠れるまでの時間
   delay_to_show: 表示されるまでの時間
   dock_side: 位置

--- a/src/ui/react/settings/i18n/translations/ko.yml
+++ b/src/ui/react/settings/i18n/translations/ko.yml
@@ -339,6 +339,7 @@ wall:
 weg:
   auto_hide: 자동 숨기기
   auto_hide_touch_disabled: 터치 스크린 장치에서는 자동 숨기기를 사용할 수 없습니다.
+  per_monitor_auto_hide: 모니터별로 독을 개별적으로 숨기기
   delay_to_hide: 숨기기 지연
   delay_to_show: 표시 지연
   dock_side: 위치

--- a/src/ui/react/settings/i18n/translations/zh-CN.yml
+++ b/src/ui/react/settings/i18n/translations/zh-CN.yml
@@ -325,6 +325,7 @@ wall:
 weg:
   auto_hide: 自动隐藏
   auto_hide_touch_disabled: 自动隐藏在触摸屏设备上不可用
+  per_monitor_auto_hide: 每个屏幕各自隐藏任务栏
   delay_to_hide: 隐藏延迟
   delay_to_show: 显示延迟
   dock_side: 位置

--- a/src/ui/react/settings/i18n/translations/zh-TW.yml
+++ b/src/ui/react/settings/i18n/translations/zh-TW.yml
@@ -329,6 +329,7 @@ wall:
 weg:
   auto_hide: 自動隱藏
   auto_hide_touch_disabled: 自動隱藏在觸控螢幕裝置上不可用
+  per_monitor_auto_hide: 每個螢幕各自隱藏工具列
   delay_to_hide: 延遲隱藏
   delay_to_show: 延遲顯示
   dock_side: 位置

--- a/src/ui/react/settings/modules/resources/Widget/seelenweg/infra.tsx
+++ b/src/ui/react/settings/modules/resources/Widget/seelenweg/infra.tsx
@@ -104,6 +104,14 @@ export const SeelenWegSettings = () => {
               onChange={(value) => patchWegConfig({ delayToHide: value || 0 })}
             />
           </SettingsOption>
+          <SettingsOption>
+            <span>{t("weg.per_monitor_auto_hide")}</span>
+            <Switch
+              checked={settings.perMonitorAutoHide}
+              disabled={settings.hideMode === HideMode.Never || isTouchPrimary}
+              onChange={(value) => patchWegConfig({ perMonitorAutoHide: value })}
+            />
+          </SettingsOption>
         </SettingsSubGroup>
       </SettingsGroup>
 

--- a/src/ui/svelte/weg/state/settings.svelte.ts
+++ b/src/ui/svelte/weg/state/settings.svelte.ts
@@ -36,6 +36,9 @@ export const settingsState = {
   get hideMode(): HideMode {
     return (this.value?.hideMode ?? HideMode.Never) as HideMode;
   },
+  get perMonitorAutoHide(): boolean {
+    return (this.value?.perMonitorAutoHide ?? false) as boolean;
+  },
   get delayToHide(): number {
     return (this.value?.delayToHide ?? 800) as number;
   },

--- a/src/ui/svelte/weg/state/windows.svelte.ts
+++ b/src/ui/svelte/weg/state/windows.svelte.ts
@@ -38,16 +38,27 @@ const _currentMonitorMaximizedColors = $derived.by((): UserAppWindowColors | nul
 });
 
 const _isDockOverlapped = $derived.by(() => {
-  // Use this monitor's own topmost window, not the globally focused one. Deriving
-  // overlap from the focused app meant a dock only hid while its own monitor was
-  // focused, so focusing another monitor made every other dock reappear even when
-  // a window still covered it. Each dock now hides based on its own monitor.
-  const by = _topInteractableWindow;
+  const monitorId = widget.decoded.monitorId;
 
-  if (!by || !by.rect) return false;
+  // Which window drives overlap-based auto-hide:
+  // - perMonitorAutoHide: this monitor's own topmost window, so each dock hides
+  //   independently based on what covers it on that monitor.
+  // - default (original author behavior): the globally focused window, only when
+  //   it is on this monitor, so just the focused monitor's dock reacts.
+  let overlapWindow: UserAppWindow | FocusedApp | null = null;
+  if (settingsState.perMonitorAutoHide) {
+    overlapWindow = _topInteractableWindow ?? null;
+  } else {
+    const f = focused.value;
+    if (f?.monitor === monitorId && interactables.value.some((w) => w.hwnd === f.hwnd)) {
+      overlapWindow = f;
+    }
+  }
+
+  const b = overlapWindow?.rect;
+  if (!b) return false;
 
   const a = widgetRect.value.hitboxRect;
-  const b = by.rect;
 
   if (a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom) {
     return false;

--- a/src/ui/svelte/weg/state/windows.svelte.ts
+++ b/src/ui/svelte/weg/state/windows.svelte.ts
@@ -38,11 +38,13 @@ const _currentMonitorMaximizedColors = $derived.by((): UserAppWindowColors | nul
 });
 
 const _isDockOverlapped = $derived.by(() => {
-  const f = focused.value;
-  const by = f?.monitor === widget.decoded.monitorId ? f : null;
+  // Use this monitor's own topmost window, not the globally focused one. Deriving
+  // overlap from the focused app meant a dock only hid while its own monitor was
+  // focused, so focusing another monitor made every other dock reappear even when
+  // a window still covered it. Each dock now hides based on its own monitor.
+  const by = _topInteractableWindow;
 
   if (!by || !by.rect) return false;
-  if (!interactables.value.some((w) => w.hwnd === by.hwnd)) return false;
 
   const a = widgetRect.value.hitboxRect;
   const b = by.rect;


### PR DESCRIPTION
## Problem
With `HideMode.OnOverlap`, a monitor's dock only hides while that monitor holds focus. Focusing a window on another monitor makes every other monitor's dock reappear even when a window still covers it there.

## Cause
`_isDockOverlapped` derives the overlap state from the single globally-focused window, so only the focused monitor reacts.

## Change
- A dock can now derive its overlap from its own monitor's topmost interactable window.
- Added a `perMonitorAutoHide` setting (default `false`, preserving the current behavior) with a toggle under Dock/Taskbar -> Auto Hide, plus en / zh-TW / zh-CN / ja / ko strings.
- Off: original globally-focused behavior. On: each dock hides/reveals independently based on what covers it on that monitor.
