### PR TITLE
fix: restore taskbar topmost state (#1688)

### DIFF
--- a/src/background/widgets/weg/mod.rs
+++ b/src/background/widgets/weg/mod.rs
@@ -9,7 +9,9 @@ use std::thread::JoinHandle;
 
 use windows::Win32::{
     Foundation::HWND,
-    UI::WindowsAndMessaging::{SW_HIDE, SW_SHOWNORMAL},
+    UI::WindowsAndMessaging::{
+        SetWindowPos, HWND_TOPMOST, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SW_HIDE, SW_SHOWNORMAL,
+    },
 };
 
 use crate::{
@@ -57,6 +59,19 @@ impl SeelenWeg {
     pub fn restore_native_taskbar() -> Result<()> {
         for hwnd in get_taskbars_handles()? {
             AppBarData::from_handle(hwnd).set_state(AppBarDataState::AlwaysOnTop);
+            
+            unsafe {
+                let _ = SetWindowPos(
+                    hwnd,
+                    HWND_TOPMOST,
+                    0,
+                    0,
+                    0,
+                    0,
+                    SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE,
+                );
+            }
+            
             WindowsApi::show_window_async(hwnd, SW_SHOWNORMAL)?;
         }
         Ok(())


### PR DESCRIPTION
可能因为原生任务栏的 AppBar 状态被修改并且没有修复导致的吧