### PR TITLE
feat(task-switcher): add window filters and preview settings

### DIFF
--- a/libs/core/src/state/settings/by_widget.rs
+++ b/libs/core/src/state/settings/by_widget.rs
@@ -12,6 +12,7 @@ const SYSTEM_WIDGET_IDS: &[&str] = &[
     "@seelen/dialog",
     "@seelen/context-menu",
     "@seelen/tooltip",
+    "@seelen/task-switcher",
 ];
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/src/background/state/application/mod.rs
+++ b/src/background/state/application/mod.rs
@@ -185,7 +185,7 @@ async fn process_changes(changed: &HashSet<PathBuf>) -> Result<()> {
         FULL_STATE.rcu(move |state| {
             let mut state = state.cloned();
             if state.sanitize_wallpaper_collections(&RESOURCES) {
-                state.emit_settings().log_error();
+                state.emit_settings(true).log_error();
             }
             state
         });
@@ -204,7 +204,7 @@ async fn process_changes(changed: &HashSet<PathBuf>) -> Result<()> {
     /* if settings_changed {
         log::info!("Seelen Settings changed");
         self.read_settings();
-        self.emit_settings()?;
+        self.emit_settings(true)?;
     } */
 
     Ok(())

--- a/src/background/state/application/settings.rs
+++ b/src/background/state/application/settings.rs
@@ -18,10 +18,12 @@ use crate::{
 use super::AppSettings;
 
 impl AppSettings {
-    pub(super) fn emit_settings(&self) -> Result<()> {
+    pub(super) fn emit_settings(&self, reconcile_widgets: bool) -> Result<()> {
         emit_to_webviews(SeelenEvent::StateSettingsChanged, &self.settings);
         SeelenUI::on_settings_change(self)?;
-        WIDGET_MANAGER.reconcile().log_error();
+        if reconcile_widgets {
+            WIDGET_MANAGER.reconcile().log_error();
+        }
         WM_STATE.lock().on_settings_changed();
         Ok(())
     }
@@ -129,8 +131,12 @@ impl AppSettings {
     }
 
     pub fn write_settings(&self) -> Result<()> {
+        self.write_settings_with_reconcile(true)
+    }
+
+    pub fn write_settings_with_reconcile(&self, reconcile_widgets: bool) -> Result<()> {
         self.settings.save(SEELEN_COMMON.settings_path())?;
-        self.emit_settings()?;
+        self.emit_settings(reconcile_widgets)?;
         Ok(())
     }
 }

--- a/src/background/state/infrastructure.rs
+++ b/src/background/state/infrastructure.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 
 use seelen_core::state::{
     by_monitor::MonitorConfiguration, by_wallpaper::WallpaperInstanceSettings, AppConfig,
@@ -9,6 +9,7 @@ use tauri_plugin_dialog::DialogExt;
 use crate::{
     app::get_app_handle,
     error::{Result, ResultLogExt},
+    resources::RESOURCES,
     state::application::{performance::PERFORMANCE_MODE, BUNDLED_SETTINGS_BY_APP},
     utils::{constants::SEELEN_COMMON, date_based_hex_id},
     windows_api::WindowsApi,
@@ -65,14 +66,57 @@ pub fn state_get_default_wallpaper_settings() -> WallpaperInstanceSettings {
 #[tauri::command(async)]
 pub fn state_write_settings(mut settings: Settings) -> Result<()> {
     settings.sanitize()?;
+    let previous = FULL_STATE.load().settings.clone();
+    let reconcile_widgets = widget_topology_changed(&previous, &settings);
     FULL_STATE.rcu(move |state| {
         let mut state = state.cloned();
         state.settings = settings.clone();
         state
     });
-    FULL_STATE.load().write_settings()?;
+    FULL_STATE
+        .load()
+        .write_settings_with_reconcile(reconcile_widgets)?;
     crate::backups::application::on_settings_saved();
     Ok(())
+}
+
+fn widget_topology_changed(previous: &Settings, next: &Settings) -> bool {
+    let monitor_ids: HashSet<_> = previous
+        .monitors_v3
+        .keys()
+        .chain(next.monitors_v3.keys())
+        .cloned()
+        .collect();
+
+    RESOURCES
+        .widgets
+        .any_sync(|widget_id, _| {
+            if previous.is_widget_enabled(widget_id) != next.is_widget_enabled(widget_id) {
+                return true;
+            }
+
+            let previous_instances = previous
+                .by_widget
+                .others
+                .get(widget_id)
+                .and_then(|config| config.instances.as_ref());
+            let next_instances = next
+                .by_widget
+                .others
+                .get(widget_id)
+                .and_then(|config| config.instances.as_ref());
+            if previous_instances.map(|instances| instances.keys().cloned().collect::<HashSet<_>>())
+                != next_instances.map(|instances| instances.keys().cloned().collect::<HashSet<_>>())
+            {
+                return true;
+            }
+
+            monitor_ids.iter().any(|monitor_id| {
+                previous.is_widget_enabled_on_monitor(widget_id, monitor_id)
+                    != next.is_widget_enabled_on_monitor(widget_id, monitor_id)
+            })
+        })
+        .is_some()
 }
 
 #[tauri::command(async)]

--- a/src/background/utils/lock_free/sync_hash_map.rs
+++ b/src/background/utils/lock_free/sync_hash_map.rs
@@ -136,6 +136,15 @@ where
     V: Clone,
 {
     #[inline]
+    pub fn get_cloned<Q: ?Sized>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash,
+    {
+        self.0.lock().get(key).cloned()
+    }
+
+    #[inline]
     pub fn to_hash_map(&self) -> HashMap<K, V> {
         self.0.lock().clone()
     }

--- a/src/background/widgets/loader.rs
+++ b/src/background/widgets/loader.rs
@@ -237,13 +237,13 @@ impl WidgetPod {
                 // APPLICATION_HANG_ENDTASK_HungThreadIsIdle crash.
                 let label = label.clone();
                 std::thread::spawn(move || {
-                    WIDGET_MANAGER.deployments.get(&label.widget_id, |deploy| {
+                    if let Some(deploy) = WIDGET_MANAGER.deployments.get_cloned(&label.widget_id) {
                         deploy.kill_pod(&label);
                         deploy.reconcile();
                         if !deploy.definition.lazy {
                             deploy.start_all_webviews();
                         }
-                    });
+                    }
                 });
             }
         });
@@ -317,11 +317,11 @@ impl WidgetPod {
                         log::warn!("Liveness prove failed for {label} (attempt {}/{LIVENESS_PROVE_MAX_RETRIES}), reloading webview.", attempt + 1);
 
                         if attempt < LIVENESS_PROVE_MAX_RETRIES {
-                            WIDGET_MANAGER.deployments.get(&label.widget_id, |deployment| {
+                            if let Some(deployment) = WIDGET_MANAGER.deployments.get_cloned(&label.widget_id) {
                                 deployment.pods.get(&label, |pod| {
                                     pod.soft_restart();
                                 });
-                            });
+                            }
                         } else {
                             log::error!("Liveness prove failed for {label} too many times, giving up.");
                             let lang = rust_i18n::locale();

--- a/src/background/widgets/loader.rs
+++ b/src/background/widgets/loader.rs
@@ -137,6 +137,11 @@ impl WidgetDeployment {
     }
 
     pub fn start_webview(&self, label: &WidgetWebviewLabel) {
+        // Lazy widgets may be triggered before their deployment thread has created the pod.
+        // Reconcile here so the first trigger can start the requested instance immediately.
+        if !self.pods.contains_key(label) {
+            self.reconcile();
+        }
         self.pods.get(label, |pod| {
             pod.run(&self.definition);
         });

--- a/src/background/widgets/manager.rs
+++ b/src/background/widgets/manager.rs
@@ -1,6 +1,6 @@
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    LazyLock,
+    Arc, LazyLock,
 };
 
 use seelen_core::{
@@ -22,7 +22,7 @@ pub static GAME_MODE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 pub struct WidgetManager {
     /// group of widgets instances by widget resource id
-    pub deployments: SyncHashMap<WidgetId, WidgetDeployment>,
+    pub deployments: SyncHashMap<WidgetId, Arc<WidgetDeployment>>,
 }
 
 impl WidgetManager {
@@ -38,25 +38,24 @@ impl WidgetManager {
 
     pub fn is_ready(&self, label: &WidgetWebviewLabel) -> bool {
         self.deployments
-            .get(&label.widget_id, |deploy| {
-                deploy.pods.any(|(key, pod)| key == label && pod.is_ready())
-            })
+            .get_cloned(&label.widget_id)
+            .map(|deploy| deploy.pods.any(|(key, pod)| key == label && pod.is_ready()))
             .unwrap_or(false)
     }
 
     pub fn set_status(&self, label: &WidgetWebviewLabel, status: WidgetStatus) {
-        self.deployments.get(&label.widget_id, |deploy| {
+        if let Some(deploy) = self.deployments.get_cloned(&label.widget_id) {
             deploy.pods.get(label, |instance| {
                 instance.set_status(status);
             });
-        });
+        }
     }
 
     pub fn suspend_all(&self) {
         GAME_MODE_ACTIVE.store(true, Ordering::Release);
-        self.deployments.for_each(|(_, deploy)| {
+        for deploy in self.deployments.values() {
             deploy.pods.clear();
-        });
+        }
     }
 
     pub fn resume_all(&self) -> Result<()> {
@@ -86,7 +85,7 @@ impl WidgetManager {
 
             if !self.deployments.contains_key(&id) {
                 self.deployments
-                    .upsert(id.clone(), WidgetDeployment::new(widget));
+                    .upsert(id.clone(), Arc::new(WidgetDeployment::new(widget)));
             }
         }
 
@@ -105,15 +104,15 @@ impl WidgetManager {
                 WidgetId::known_toolbar(),
                 WidgetId::known_weg(),
             ] {
-                WIDGET_MANAGER.deployments.get(&priority, |deployment| {
-                    reconcile(deployment);
-                });
+                if let Some(deployment) = WIDGET_MANAGER.deployments.get_cloned(&priority) {
+                    reconcile(&deployment);
+                }
             }
 
-            // All other widgets
-            WIDGET_MANAGER.deployments.for_each(|(_, deployment)| {
-                reconcile(deployment);
-            });
+            // Clone the Arc handles while locked, then perform webview work outside the map lock.
+            for deployment in WIDGET_MANAGER.deployments.values() {
+                reconcile(&deployment);
+            }
         });
 
         Ok(())

--- a/src/background/widgets/mod.rs
+++ b/src/background/widgets/mod.rs
@@ -97,11 +97,11 @@ fn trigger_widget_inner(
                 return Err("Instance id is required for multiple instance widgets".into());
             };
 
-            WIDGET_MANAGER.deployments.get(&payload.id, |container| {
+            if let Some(container) = WIDGET_MANAGER.deployments.get_cloned(&payload.id) {
                 if !container.pods.contains_key(&label) {
                     container.create_runtime_instance(instance_id, owner_hwnd);
                 }
-            });
+            }
         }
     }
 
@@ -125,9 +125,9 @@ fn trigger_widget_inner(
         log::trace!("Trigger postponed, because widget instance is not ready: {label}");
         PENDING_TRIGGERS.upsert(label.clone(), payload);
 
-        WIDGET_MANAGER.deployments.get(&label.widget_id, |c| {
+        if let Some(c) = WIDGET_MANAGER.deployments.get_cloned(&label.widget_id) {
             c.start_webview(&label);
-        });
+        }
         return Ok(());
     }
 
@@ -295,7 +295,7 @@ fn widget_data_dir(webview: &tauri::WebviewWindow) -> Result<PathBuf> {
 pub fn notify_widget_statuses_change() {
     std::thread::spawn(|| {
         let mut result = Vec::new();
-        WIDGET_MANAGER.deployments.for_each(|(_, deployment)| {
+        for deployment in WIDGET_MANAGER.deployments.values() {
             deployment.pods.for_each(|(_, pod)| {
                 result.push(WidgetDebugInfo {
                     label: pod.label.raw.clone(),
@@ -306,7 +306,7 @@ pub fn notify_widget_statuses_change() {
                     webview_window_id: pod.hwnd(),
                 });
             });
-        });
+        }
         emit_to_webviews(SeelenEvent::WidgetDebugInfoChanged, result);
     });
 }
@@ -314,7 +314,7 @@ pub fn notify_widget_statuses_change() {
 #[tauri::command(async)]
 pub fn debug_get_widgets_statuses() -> Vec<WidgetDebugInfo> {
     let mut result = Vec::new();
-    WIDGET_MANAGER.deployments.for_each(|(_, deployment)| {
+    for deployment in WIDGET_MANAGER.deployments.values() {
         deployment.pods.for_each(|(_, pod)| {
             result.push(WidgetDebugInfo {
                 label: pod.label.raw.clone(),
@@ -325,7 +325,7 @@ pub fn debug_get_widgets_statuses() -> Vec<WidgetDebugInfo> {
                 webview_window_id: pod.hwnd(),
             });
         });
-    });
+    }
     result
 }
 

--- a/src/background/windows_api/event_window.rs
+++ b/src/background/windows_api/event_window.rs
@@ -139,11 +139,11 @@ impl BgWindowProc {
         if !previous && is_interactive {
             // reload all pods webviews on session resume
             std::thread::spawn(move || {
-                WIDGET_MANAGER.deployments.for_each(|(_, deployment)| {
+                for deployment in WIDGET_MANAGER.deployments.values() {
                     deployment.pods.for_each(|(_, pod)| {
                         pod.soft_restart();
                     });
-                });
+                }
             });
         }
     }

--- a/src/static/widgets/task-switcher/i18n/settings/preview-delay-description.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/preview-delay-description.yml
@@ -1,0 +1,2 @@
+en: Delay available to themes that show window previews on pointer hover.
+zh-CN: 供支持鼠标悬浮窗口预览的主题使用的延迟时间。

--- a/src/static/widgets/task-switcher/i18n/settings/preview-delay.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/preview-delay.yml
@@ -1,0 +1,2 @@
+en: Theme hover delay (milliseconds)
+zh-CN: 主题悬浮延迟（毫秒）

--- a/src/static/widgets/task-switcher/i18n/settings/preview-enabled.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/preview-enabled.yml
@@ -1,0 +1,2 @@
+en: Show window previews
+zh-CN: 显示窗口预览

--- a/src/static/widgets/task-switcher/i18n/settings/preview-group.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/preview-group.yml
@@ -1,0 +1,2 @@
+en: Window preview
+zh-CN: 窗口预览

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-all.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-all.yml
@@ -1,0 +1,2 @@
+en: All windows
+zh-CN: 所有窗口

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-blacklist.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-blacklist.yml
@@ -1,0 +1,2 @@
+en: Blacklist
+zh-CN: 黑名单

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-whitelist.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-mode-whitelist.yml
@@ -1,0 +1,2 @@
+en: Whitelist
+zh-CN: 白名单

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-mode.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-mode.yml
@@ -1,0 +1,2 @@
+en: Window filter mode
+zh-CN: 窗口筛选模式

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-patterns-description.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-patterns-description.yml
@@ -1,0 +1,2 @@
+en: One entry per line. Entries match an app name, window title, executable name, or executable path, case-insensitively. An empty list disables filtering.
+zh-CN: 每行填写一项。条目会不区分大小写地匹配应用名、窗口标题、可执行文件名或可执行文件路径。留空表示不筛选。

--- a/src/static/widgets/task-switcher/i18n/settings/window-filter-patterns.yml
+++ b/src/static/widgets/task-switcher/i18n/settings/window-filter-patterns.yml
@@ -1,0 +1,2 @@
+en: Filter entries
+zh-CN: 筛选条目

--- a/src/static/widgets/task-switcher/metadata.yml
+++ b/src/static/widgets/task-switcher/metadata.yml
@@ -7,6 +7,44 @@ instances: Single
 loader: Internal
 preset: Overlay
 hidden: true
+settings:
+  - type: select
+    key: windowFilterMode
+    label: !extend i18n/settings/window-filter-mode.yml
+    options:
+      - value: all
+        label: !extend i18n/settings/window-filter-mode-all.yml
+      - value: blacklist
+        label: !extend i18n/settings/window-filter-mode-blacklist.yml
+      - value: whitelist
+        label: !extend i18n/settings/window-filter-mode-whitelist.yml
+    defaultValue: all
+
+  - type: text
+    key: windowFilterPatterns
+    label: !extend i18n/settings/window-filter-patterns.yml
+    description: !extend i18n/settings/window-filter-patterns-description.yml
+    defaultValue: ""
+    multiline: true
+
+  - group:
+      label: !extend i18n/settings/preview-group.yml
+      items:
+        - type: switch
+          key: previewEnabled
+          label: !extend i18n/settings/preview-enabled.yml
+          defaultValue: true
+
+        - type: number
+          key: previewDelay
+          label: !extend i18n/settings/preview-delay.yml
+          description: !extend i18n/settings/preview-delay-description.yml
+          defaultValue: 1000
+          dependencies: [previewEnabled]
+          min: 0
+          max: 5000
+          step: 100
+
 shortcuts:
   - id: task-switcher-next-auto
     command: ["task-switcher", "select-next-task", "--auto-confirm"]

--- a/src/ui/react/settings/i18n/translations/en.yml
+++ b/src/ui/react/settings/i18n/translations/en.yml
@@ -424,6 +424,18 @@ widget:
   extra_instances: Extra Instances
   instance: Instance
   instances: Instances
+task_switcher:
+  application_list:
+    title: Running applications
+    description: Add or remove the visible applications with one click.
+    search: Search running applications
+    refresh: Refresh application list
+    add: Add to filter
+    remove: Remove from filter
+    empty: No matching running applications
+    load_failed: Could not load running applications
+    no_path: Executable path unavailable
+    windows: "{{count}} window(s)"
 wm:
   animations:
     duration: Animation Duration (ms)

--- a/src/ui/react/settings/i18n/translations/zh-CN.yml
+++ b/src/ui/react/settings/i18n/translations/zh-CN.yml
@@ -377,6 +377,18 @@ widget:
   extra_instances: 额外实例
   instance: 实例
   instances: 实例
+task_switcher:
+  application_list:
+    title: 当前运行的应用
+    description: 点击按钮即可将应用加入或移出筛选列表。
+    search: 搜索当前运行的应用
+    refresh: 刷新应用列表
+    add: 添加到筛选列表
+    remove: 从筛选列表移除
+    empty: 没有匹配的运行中应用
+    load_failed: 无法加载当前运行的应用
+    no_path: 无法获取可执行文件路径
+    windows: "{{count}} 个窗口"
 wm:
   animations:
     duration: 动画时长（毫秒）

--- a/src/ui/react/settings/modules/resources/Widget/AllView.tsx
+++ b/src/ui/react/settings/modules/resources/Widget/AllView.tsx
@@ -12,7 +12,13 @@ import { getWidgetConfig, patchWidgetConfig } from "./application.ts";
 
 import { resolveDisplayName, ResourceCard, ResourceListHeader } from "../ResourceCard.tsx";
 
-const SYSTEM_WIDGET_IDS = ["@seelen/settings", "@seelen/dialog", "@seelen/context-menu", "@seelen/tooltip"];
+const SYSTEM_WIDGET_IDS = [
+  "@seelen/settings",
+  "@seelen/dialog",
+  "@seelen/context-menu",
+  "@seelen/tooltip",
+  "@seelen/task-switcher",
+];
 
 function WidgetItem({ widget }: { widget: Widget }) {
   const rootConfig = getWidgetConfig(widget.id);

--- a/src/ui/react/settings/modules/resources/Widget/TaskSwitcherWindowPicker.module.css
+++ b/src/ui/react/settings/modules/resources/Widget/TaskSwitcherWindowPicker.module.css
@@ -1,0 +1,71 @@
+.header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-xs);
+}
+
+.description {
+  flex: 1;
+  color: var(--color-gray-600);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  overflow-y: auto;
+  margin-top: var(--spacing-xs);
+}
+
+.status {
+  display: grid;
+  min-height: 96px;
+  place-items: center;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 32px;
+  align-items: center;
+  gap: var(--spacing-xs);
+  min-height: 44px;
+  padding: 5px 6px;
+  border-bottom: 1px solid light-dark(#00000010, #ffffff12);
+}
+
+.icon {
+  width: 25px;
+  height: 25px;
+}
+
+.info {
+  min-width: 0;
+}
+
+.name,
+.meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.name {
+  font-weight: 600;
+}
+
+.meta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--spacing-xs);
+  color: var(--color-gray-600);
+  font-size: 0.72rem;
+}
+
+.meta > :first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/ui/react/settings/modules/resources/Widget/TaskSwitcherWindowPicker.tsx
+++ b/src/ui/react/settings/modules/resources/Widget/TaskSwitcherWindowPicker.tsx
@@ -1,0 +1,186 @@
+import { invoke, SeelenCommand, SeelenEvent, subscribe } from "@seelen-ui/lib";
+import type { UserAppWindow } from "@seelen-ui/lib/types";
+import { Button, Empty, Input, Spin, Tooltip } from "antd";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { FileIcon, Icon } from "libs/ui/react/components/Icon";
+import { SettingsGroup, SettingsSubGroup } from "../../../components/SettingsBox/index.tsx";
+import { useTranslation } from "react-i18next";
+import cs from "./TaskSwitcherWindowPicker.module.css";
+
+interface Props {
+  mode: string;
+  patterns: string;
+  onChange: (patterns: string) => void;
+}
+
+interface AppEntry {
+  key: string;
+  name: string;
+  executable: string;
+  path: string | null;
+  umid: string | null;
+  windows: number;
+}
+
+function executableName(path: string | null) {
+  return path?.split(/[\\/]/).pop() || "";
+}
+
+function makeEntries(windows: UserAppWindow[]): AppEntry[] {
+  const entries = new Map<string, AppEntry>();
+  for (const window of windows) {
+    const path = window.process.path;
+    const executable = executableName(path);
+    const key = (path || executable || window.appName || window.title).toLowerCase();
+    const current = entries.get(key);
+    if (current) {
+      current.windows += 1;
+      continue;
+    }
+    entries.set(key, {
+      key,
+      name: window.appName || executable || window.title,
+      executable,
+      path,
+      umid: window.umid,
+      windows: 1,
+    });
+  }
+  return [...entries.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function parsePatterns(patterns: string) {
+  return patterns.split(/\r?\n/).map((pattern) => pattern.trim()).filter(Boolean);
+}
+
+function matchingPatterns(entry: AppEntry, patterns: string[]) {
+  const values = [entry.name, entry.executable, entry.path]
+    .filter((value): value is string => !!value)
+    .map((value) => value.toLowerCase());
+  return patterns.filter((pattern) => values.some((value) => value.includes(pattern.toLowerCase())));
+}
+
+export function TaskSwitcherWindowPicker({ mode, patterns, onChange }: Props) {
+  const { t } = useTranslation();
+  const [windows, setWindows] = useState<UserAppWindow[]>([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setLoadFailed(false);
+    try {
+      setWindows(await invoke(SeelenCommand.GetUserAppWindows));
+    } catch {
+      setLoadFailed(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    void refresh();
+    let unsubscribe: (() => void) | undefined;
+    void subscribe(SeelenEvent.UserAppWindowsChanged, ({ payload }) => {
+      if (active) {
+        setWindows(payload);
+        setLoading(false);
+        setLoadFailed(false);
+      }
+    }).then((stop) => {
+      if (active) {
+        unsubscribe = stop;
+      } else {
+        stop();
+      }
+    });
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [refresh]);
+
+  const entries = useMemo(() => makeEntries(windows), [windows]);
+  const visibleEntries = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return entries;
+    return entries.filter((entry) =>
+      [entry.name, entry.executable, entry.path].some((value) => value?.toLowerCase().includes(query))
+    );
+  }, [entries, search]);
+
+  if (mode !== "blacklist" && mode !== "whitelist") return null;
+
+  const current = parsePatterns(patterns);
+
+  const toggle = (entry: AppEntry) => {
+    const matched = new Set(matchingPatterns(entry, current));
+    const next = matched.size > 0
+      ? current.filter((pattern) => !matched.has(pattern))
+      : [...current, entry.executable || entry.name];
+    onChange(next.join("\n"));
+  };
+
+  return (
+    <SettingsGroup>
+      <SettingsSubGroup label={t("task_switcher.application_list.title")}>
+        <div className={cs.header}>
+          <span className={cs.description}>{t("task_switcher.application_list.description")}</span>
+          <Button
+            type="text"
+            title={t("task_switcher.application_list.refresh")}
+            aria-label={t("task_switcher.application_list.refresh")}
+            icon={<Icon iconName="RiRefreshLine" />}
+            loading={loading}
+            onClick={() => void refresh()}
+          />
+        </div>
+        <Input.Search
+          allowClear
+          value={search}
+          placeholder={t("task_switcher.application_list.search")}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+        />
+        <div className={cs.list}>
+          {loading && windows.length === 0
+            ? <div className={cs.status}><Spin size="small" /></div>
+            : visibleEntries.map((entry) => {
+            const included = matchingPatterns(entry, current).length > 0;
+            return (
+              <div className={cs.row} key={entry.key}>
+                <FileIcon path={entry.path} umid={entry.umid} className={cs.icon} />
+                <div className={cs.info}>
+                  <div className={cs.name}>{entry.name}</div>
+                  <div className={cs.meta}>
+                    {entry.executable || entry.path || t("task_switcher.application_list.no_path")}
+                    <span>{t("task_switcher.application_list.windows", { count: entry.windows })}</span>
+                  </div>
+                </div>
+                <Tooltip title={included ? t("task_switcher.application_list.remove") : t("task_switcher.application_list.add")}>
+                  <Button
+                    type={included ? "primary" : "default"}
+                    shape="circle"
+                    aria-label={included ? t("task_switcher.application_list.remove") : t("task_switcher.application_list.add")}
+                    icon={<Icon iconName={included ? "RiCheckLine" : "RiAddLine"} />}
+                    onClick={() => toggle(entry)}
+                  />
+                </Tooltip>
+              </div>
+            );
+          })}
+          {!loading && visibleEntries.length === 0 && (
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description={t(loadFailed
+                ? "task_switcher.application_list.load_failed"
+                : "task_switcher.application_list.empty")}
+            />
+          )}
+        </div>
+      </SettingsSubGroup>
+    </SettingsGroup>
+  );
+}

--- a/src/ui/react/settings/modules/resources/Widget/View.tsx
+++ b/src/ui/react/settings/modules/resources/Widget/View.tsx
@@ -29,6 +29,7 @@ import { WallSettings } from "./Wall/infra.tsx";
 import { Icon } from "libs/ui/react/components/Icon/index.tsx";
 import { Note } from "../../../components/Note/index.tsx";
 import { WindowManagerSettings } from "./WindowManager/main/infra/index.tsx";
+import { TaskSwitcherWindowPicker } from "./TaskSwitcherWindowPicker.tsx";
 
 export function WidgetConfiguration({
   widgetId,
@@ -153,6 +154,14 @@ export function WidgetConfiguration({
         onConfigChange={onConfigChange}
         isByMonitor={!!monitorId}
       />
+
+      {widgetId === "@seelen/task-switcher" && !monitorId && (
+        <TaskSwitcherWindowPicker
+          mode={typeof config.windowFilterMode === "string" ? config.windowFilterMode : "all"}
+          patterns={typeof config.windowFilterPatterns === "string" ? config.windowFilterPatterns : ""}
+          onChange={(patterns) => onConfigChange("windowFilterPatterns", patterns)}
+        />
+      )}
 
       {children}
 

--- a/src/ui/react/settings/modules/resources/Widget/View.tsx
+++ b/src/ui/react/settings/modules/resources/Widget/View.tsx
@@ -82,7 +82,8 @@ export function WidgetConfiguration({
     ...(monitorConfig || {}),
   };
 
-  const showToggleEnabled = !monitorId || widget.instances === "ReplicaByMonitor";
+  const showToggleEnabled = (!monitorId || widget.instances === "ReplicaByMonitor") &&
+    widgetId !== "@seelen/task-switcher";
 
   const widgetPlugins = widget.plugins;
 

--- a/src/ui/svelte/task-switcher/App.svelte
+++ b/src/ui/svelte/task-switcher/App.svelte
@@ -10,6 +10,7 @@
 
 <div
   class="task-switcher-overlay"
+  style:--task-switcher-preview-delay={`${globalState.previewDelay}ms`}
   role="dialog"
   tabindex="-1"
   onclick={() => {

--- a/src/ui/svelte/task-switcher/components/TaskItem.svelte
+++ b/src/ui/svelte/task-switcher/components/TaskItem.svelte
@@ -14,7 +14,9 @@
 
   let boxRef: HTMLDivElement | undefined = $state();
   const isSelected = $derived(task.hwnd === globalState.selectedWindow);
-  const preview = $derived(globalState.previews[task.hwnd]);
+  const preview = $derived(
+    globalState.previewEnabled ? globalState.previews[task.hwnd] : undefined,
+  );
 
   // Focus button when selected
   $effect(() => {
@@ -102,11 +104,13 @@
       <Icon iconName="TbX" />
     </button>
   </div>
-  <div class="task-preview-container">
-    {#if preview}
-      <img class="task-preview" src={`data:image/webp;base64,${preview.data}`} alt="" />
-    {:else}
-      <MissingIcon class="task-no-preview" />
-    {/if}
-  </div>
+  {#if globalState.previewEnabled}
+    <div class="task-preview-container">
+      {#if preview}
+        <img class="task-preview" src={`data:image/webp;base64,${preview.data}`} alt="" />
+      {:else}
+        <MissingIcon class="task-no-preview" />
+      {/if}
+    </div>
+  {/if}
 </div>

--- a/src/ui/svelte/task-switcher/state.svelte.ts
+++ b/src/ui/svelte/task-switcher/state.svelte.ts
@@ -1,12 +1,65 @@
-import { invoke, SeelenCommand, SeelenEvent, subscribe, Widget } from "@seelen-ui/lib";
+import { invoke, SeelenCommand, SeelenEvent, Settings, subscribe, Widget } from "@seelen-ui/lib";
+import type { UserAppWindow } from "@seelen-ui/lib/types";
 import { lazyRune } from "libs/ui/svelte/utils/LazyRune.svelte.ts";
 
 const widget = Widget.getCurrent();
+
+type WindowFilterMode = "all" | "blacklist" | "whitelist";
+
+interface TaskSwitcherSettings {
+  windowFilterMode: WindowFilterMode;
+  windowFilterPatterns: string;
+  previewEnabled: boolean;
+  previewDelay: number;
+}
+
+function getTaskSwitcherSettings(settings: Settings): TaskSwitcherSettings {
+  const config = settings.getCurrentWidgetConfig();
+  const mode = config.windowFilterMode;
+  const delay = Number(config.previewDelay);
+
+  return {
+    windowFilterMode: mode === "blacklist" || mode === "whitelist" ? mode : "all",
+    windowFilterPatterns: typeof config.windowFilterPatterns === "string" ? config.windowFilterPatterns : "",
+    previewEnabled: typeof config.previewEnabled === "boolean" ? config.previewEnabled : true,
+    previewDelay: Number.isFinite(delay) ? Math.min(5000, Math.max(0, delay)) : 1000,
+  };
+}
+
+function filterWindows(
+  windows: UserAppWindow[],
+  { windowFilterMode, windowFilterPatterns }: TaskSwitcherSettings,
+): UserAppWindow[] {
+  const patterns = windowFilterPatterns
+    .split(/\r?\n/)
+    .map((pattern) => pattern.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (windowFilterMode === "all" || patterns.length === 0) {
+    return windows;
+  }
+
+  return windows.filter((window) => {
+    const executablePath = window.process.path?.toLowerCase() ?? "";
+    const executableName = executablePath.split(/[\\/]/).pop() ?? "";
+    const searchableValues = [
+      window.appName.toLowerCase(),
+      window.title.toLowerCase(),
+      executableName,
+      executablePath,
+    ];
+    const matches = patterns.some((pattern) => searchableValues.some((value) => value.includes(pattern)));
+
+    return windowFilterMode === "whitelist" ? matches : !matches;
+  });
+}
 
 // +++++++++++++++++++++++ Reactive State +++++++++++++++++++++++
 
 let showing = $state(false);
 let autoConfirm = $state(false);
+
+let settings = lazyRune(async () => getTaskSwitcherSettings(await Settings.getAsync()));
 
 let windows = lazyRune(async () =>
   (await invoke(SeelenCommand.GetUserAppWindows)).toSorted(
@@ -17,8 +70,32 @@ subscribe(SeelenEvent.UserAppWindowsChanged, ({ payload }) => {
   windows.value = payload.toSorted((a, b) => b.lastForegroundAt - a.lastForegroundAt);
 });
 
-let previews = lazyRune(() => invoke(SeelenCommand.GetUserAppWindowsPreviews));
-subscribe(SeelenEvent.UserAppWindowsPreviewsChanged, previews.setByPayload);
+let previews = lazyRune(async () =>
+  settings.value.previewEnabled ? await invoke(SeelenCommand.GetUserAppWindowsPreviews) : {}
+);
+subscribe(SeelenEvent.UserAppWindowsPreviewsChanged, (event) => {
+  if (settings.isInitialized() && settings.value.previewEnabled) {
+    previews.setByPayload(event);
+  }
+});
+
+async function refreshPreviews() {
+  const nextPreviews = await invoke(SeelenCommand.GetUserAppWindowsPreviews);
+  if (settings.value.previewEnabled) {
+    previews.value = nextPreviews;
+  }
+}
+
+Settings.onChange((nextSettings) => {
+  const wasPreviewEnabled = settings.isInitialized() && settings.value.previewEnabled;
+  settings.value = getTaskSwitcherSettings(nextSettings);
+
+  if (!settings.value.previewEnabled && previews.isInitialized()) {
+    previews.value = {};
+  } else if (settings.value.previewEnabled && !wasPreviewEnabled && previews.isInitialized()) {
+    void refreshPreviews();
+  }
+});
 
 let focusedWinId = lazyRune(async () => (await invoke(SeelenCommand.GetFocusedApp)).hwnd);
 subscribe(SeelenEvent.GlobalFocusChanged, (e) => {
@@ -28,16 +105,20 @@ subscribe(SeelenEvent.GlobalFocusChanged, (e) => {
 let monitors = lazyRune(() => invoke(SeelenCommand.SystemGetMonitors));
 subscribe(SeelenEvent.SystemMonitorsChanged, monitors.setByPayload);
 
+await settings.init();
 await Promise.all([windows.init(), previews.init(), focusedWinId.init(), monitors.init()]);
 
+let filteredWindows = $derived.by(() => filterWindows(windows.value, settings.value));
 let selectedWindow = $state<number | null>(focusedWinId.value ?? null);
 
-// Sync selectedWindow with focused window when the switcher is not visible
+// Keep the selection inside the filtered window set as windows or settings change.
 $effect.root(() => {
   $effect(() => {
     if (!showing) {
-      const win = windows.value.find((w) => w.hwnd === focusedWinId.value);
+      const win = filteredWindows.find((w) => w.hwnd === focusedWinId.value);
       selectedWindow = win?.hwnd ?? null;
+    } else if (!filteredWindows.some((window) => window.hwnd === selectedWindow)) {
+      selectedWindow = filteredWindows[0]?.hwnd ?? null;
     }
   });
 });
@@ -54,7 +135,7 @@ class State {
   }
 
   get windows() {
-    return windows.value;
+    return filteredWindows;
   }
 
   get previews() {
@@ -67,6 +148,14 @@ class State {
 
   set selectedWindow(value: number | null) {
     selectedWindow = value;
+  }
+
+  get previewEnabled() {
+    return settings.value.previewEnabled;
+  }
+
+  get previewDelay() {
+    return settings.value.previewDelay;
   }
 }
 
@@ -112,33 +201,36 @@ $effect.root(() => {
 // +++++++++++++++++++++++ Triggering +++++++++++++++++++++++
 
 function onAltKeyUp() {
-  if (showing && selectedWindow && autoConfirm) {
+  if (showing && autoConfirm) {
     showing = false;
-    invoke(SeelenCommand.WegToggleWindowState, {
-      hwnd: selectedWindow,
-      wasFocused: false,
-    });
+    if (selectedWindow) {
+      invoke(SeelenCommand.WegToggleWindowState, {
+        hwnd: selectedWindow,
+        wasFocused: false,
+      });
+    }
   }
 }
 
 widget.onTrigger((payload) => {
   const direction: string = (payload.customArgs?.direction as string) || "next";
   const autoConfirmValue: boolean = (payload.customArgs?.autoConfirm as boolean) || false;
+  const availableWindows = filteredWindows;
 
-  if (windows.value.length === 0) {
+  if (availableWindows.length === 0) {
     return;
   }
 
   // Use the currently selected window when already showing, otherwise start from focused
   const currentHwnd = showing ? selectedWindow : focusedWinId.value;
 
-  let index = windows.value.findIndex((w) => w.hwnd === currentHwnd);
+  let index = availableWindows.findIndex((w) => w.hwnd === currentHwnd);
   if (direction === "next") {
-    if (index === -1) index = windows.value.length - 1;
-    selectedWindow = windows.value[(index + 1) % windows.value.length]?.hwnd ?? null;
+    if (index === -1) index = availableWindows.length - 1;
+    selectedWindow = availableWindows[(index + 1) % availableWindows.length]?.hwnd ?? null;
   } else if (direction === "previous") {
     if (index === -1) index = 0;
-    selectedWindow = windows.value[(index - 1 + windows.value.length) % windows.value.length]?.hwnd ?? null;
+    selectedWindow = availableWindows[(index - 1 + availableWindows.length) % availableWindows.length]?.hwnd ?? null;
   }
 
   // Only capture autoConfirm on the first trigger (when switcher was hidden)


### PR DESCRIPTION
## Summary

- add Task Switcher-specific all/blacklist/whitelist window filtering
- match newline-separated entries against app name, window title, executable name, and executable path, case-insensitively
- add a settings picker showing currently running applications with icons, executable names, paths, window counts, search, refresh, and one-click add/remove actions
- add a setting to disable window previews and avoid fetching preview data while disabled
- expose a configurable preview hover delay as `--task-switcher-preview-delay`, defaulting to 1000 ms
- make the hidden Task Switcher configurable from the Widgets resource list while keeping this system widget non-disableable
- avoid holding the global widget deployment lock during WebView operations; reconcile lazy deployments before their first trigger

## Scope

Filtering is applied only in the Task Switcher frontend. The global `GetUserAppWindows` enumeration and its consumers, including the Dock and Window Manager, are unchanged.

An empty filter list behaves like `all`, including in blacklist and whitelist mode. An application row is grouped by executable path and can be searched by app name, executable, or path. If filtering removes the current selection while the switcher is open, selection moves to the first remaining window.

The default theme continues to render its existing preview layout. Themes that reveal previews on hover can consume `--task-switcher-preview-delay`; the default value is 1000 ms.

## Validation

- `npm run build:ui`
- `cargo build --locked`
- pre-push Rust tests (all passed)
- `git diff --check`
- post-restart process check: `seelen-ui.exe` and `slu-service.exe` running from the Debug build
- no Windows Application Error event after the 18:52 restart

`npm run type-check` remains blocked only by the local machine's missing `deno` executable in its final step.