### PR TITLE
fix(wm): prevent toolbar and dock from being permanently overlapped

### DIFF
--- a/src/background/modules/apps/application/windows.rs
+++ b/src/background/modules/apps/application/windows.rs
@@ -168,6 +168,8 @@ impl UserAppsManager {
             WinEvent::SystemForeground => {
                 let now = now_millis();
                 data.last_foreground_at = now;
+                let window = Window::from(data.hwnd);
+                data.is_fullscreen = window.is_fullscreen();
                 true
             }
             WinEvent::SystemMinimizeStart => {

--- a/src/ui/svelte/fancy-toolbar/App.svelte
+++ b/src/ui/svelte/fancy-toolbar/App.svelte
@@ -29,7 +29,7 @@
     if (value) {
       invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.TopMost });
     } else {
-      invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.Bottom });
+      invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.NoTopMost });
     }
   }, 200);
 
@@ -38,6 +38,7 @@
   });
 
   onMount(() => {
+    invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.TopMost });
     Widget.self.ready().then(() => {
       settingsState.isReady = true;
     });

--- a/src/ui/svelte/fancy-toolbar/state/windows.svelte.ts
+++ b/src/ui/svelte/fancy-toolbar/state/windows.svelte.ts
@@ -7,11 +7,15 @@ export { focused, interactables, widgetStatuses, windowsColors };
 
 const widget = Widget.getCurrent();
 
-const _topInteractableWindow = $derived(
-  interactables.value
-    .toSorted((a, b) => b.lastForegroundAt - a.lastForegroundAt)
-    .find((w) => w.monitor === widget.decoded.monitorId && !w.isIconic),
-);
+const _topInteractableWindow = $derived.by(() => {
+  const fg = focused.value;
+  if (!fg) return null;
+  const app = interactables.value.find((w) => w.hwnd === fg.hwnd);
+  if (app && app.monitor === widget.decoded.monitorId && !app.isIconic) {
+    return app;
+  }
+  return null;
+});
 
 const _thereIsMaximizedOnBg = $derived(
   interactables.value.some(

--- a/src/ui/svelte/weg/App.svelte
+++ b/src/ui/svelte/weg/App.svelte
@@ -25,7 +25,7 @@
     if (value) {
       invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.TopMost });
     } else {
-      invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.Bottom });
+      invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.NoTopMost });
     }
   }, 200);
 
@@ -34,6 +34,7 @@
   });
 
   onMount(() => {
+    invoke(SeelenCommand.SetSelfZOrder, { zOrder: ZOrder.TopMost });
     Widget.self.ready().then(() => {
       settingsState.isReady = true;
     });

--- a/src/ui/svelte/weg/state/windows.svelte.ts
+++ b/src/ui/svelte/weg/state/windows.svelte.ts
@@ -22,11 +22,15 @@ subscribe(SeelenEvent.GlobalFocusChanged, (e) => {
   }
 });
 
-const _topInteractableWindow = $derived(
-  interactables.value
-    .toSorted((a, b) => b.lastForegroundAt - a.lastForegroundAt)
-    .find((w) => w.monitor === widget.decoded.monitorId && !w.isIconic),
-);
+const _topInteractableWindow = $derived.by(() => {
+  const fg = focused.value;
+  if (!fg) return null;
+  const app = interactables.value.find((w) => w.hwnd === fg.hwnd);
+  if (app && app.monitor === widget.decoded.monitorId && !app.isIconic) {
+    return app;
+  }
+  return null;
+});
 
 const _currentMonitorMaximizedColors = $derived.by((): UserAppWindowColors | null => {
   const monitorId = widget.decoded.monitorId;


### PR DESCRIPTION
- Change z-order demotion from HWND_BOTTOM to HWND_NOTOPMOST so widgets never sink below all desktop windows permanently
- Refresh is_fullscreen flag on SystemForeground event to prevent stale fullscreen state from locking widgets at the bottom of the z-order
- Derive top interactable window from current focused window instead of stale lastForegroundAt sorting to avoid false fullscreen detection

Closes #1702