### PR TITLE
fix(tb): stop showing the muted icon when the default audio device is lost

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@
 - launched apps not seeing environment variable changes made after Seelen UI started.
 - context menu metadata not being send for submenus.
 - context menu not being close on submenu item interaction.
+- toolbar showing the muted volume icon when there is no default audio output device.
+- default audio device flags being cleared when the new default device was not loaded yet.
 
 ## [2.8.2]
 

--- a/libs/ui/svelte/utils/scopes.svelte.ts
+++ b/libs/ui/svelte/utils/scopes.svelte.ts
@@ -213,8 +213,12 @@ function mediaStep(data: Data): boolean {
   const defaultOutputDevice = mediaOutputs.find((d: any) => d.isDefaultMultimedia);
   const defaultInputDevice = mediaInputs.find((d: any) => d.isDefaultMultimedia);
   const defaultMediaSession = _mediaSessions.data?.find((d: any) => d.default);
-  const { volume = 0, muted: isMuted = true } = defaultOutputDevice || {};
-  const { volume: inputVolume = 0, muted: inputIsMuted = true } = defaultInputDevice || {};
+  // Defaulting `muted` to true when there is no default device makes "no output
+  // device" render with the very same muted icon as a device the user actually
+  // muted, so the toolbar reports a mute that does not exist. Falling back to
+  // false keeps volume at 0, which renders the distinct "no output" icon.
+  const { volume = 0, muted: isMuted = false } = defaultOutputDevice || {};
+  const { volume: inputVolume = 0, muted: inputIsMuted = false } = defaultInputDevice || {};
 
   data.defaultOutputDevice = defaultOutputDevice;
   data.defaultInputDevice = defaultInputDevice;

--- a/src/background/modules/media/devices/application.rs
+++ b/src/background/modules/media/devices/application.rs
@@ -249,6 +249,17 @@ impl DevicesManager {
                     &self.outputs
                 };
 
+                // Windows can report a new default device before we have loaded it,
+                // e.g. a bluetooth endpoint that is still being enumerated. Flagging
+                // blindly would then clear the flag on every device and set it on
+                // none, leaving the UI with no default device at all.
+                if !device_id.is_empty()
+                    && !devices.contains_key(device_id)
+                    && let Some(raw) = self.get_raw_device(device_id)
+                {
+                    self.load_device(&raw).log_error();
+                }
+
                 devices.for_each(|(_, device)| {
                     if *role == eMultimedia {
                         device.is_default_multimedia = device.id == *device_id;


### PR DESCRIPTION
## Problem

The toolbar volume icon shows the **muted** icon while the default output device is playing
audio normally. Windows reports the device as default, unmuted and at 100%, but
`@seelen/tb-media-popup` keeps drawing `IoVolumeMuteOutline` until Seelen UI is restarted.

Reproduced on 2.8.2 (Windows 11 26200, bluetooth speaker):

1. Play audio on a bluetooth output device, everything looks right.
2. Turn the bluetooth radio off and on again, or power-cycle the speaker, so the endpoint
   disappears and comes back.
3. The device reconnects and audio works, but the toolbar icon stays muted. Restarting
   `seelen-ui` is the only way to recover it.

## Root cause

Two separate bugs that compound each other.

**1. `DefaultDeviceChanged` can clear every default flag.**
`IMMNotificationClient::OnDefaultDeviceChanged` can report a device that `DevicesManager` has
not loaded yet, which happens routinely with bluetooth endpoints that are still being
enumerated. The handler then walks the map comparing ids:

```rust
devices.for_each(|(_, device)| {
    if *role == eMultimedia {
        device.is_default_multimedia = device.id == *device_id;
    }
});
```

Nothing matches, so the flag is cleared on every device and set on none. From that point on
the manager reports no default device at all.

**2. "no default device" is rendered as "muted".**
`mediaStep` defaults `muted` to `true` when there is no default device:

```ts
const { volume = 0, muted: isMuted = true } = defaultOutputDevice || {};
```

and the plugin template starts with `return isMuted ? icon("IoVolumeMuteOutline") : ...`, so a
device the user actually muted and a device the manager has lost are drawn with the exact same
icon. The toolbar reports a mute that does not exist.

## Fix

- `application.rs`: when the reported default id is not in the map, load that device first, so
  the flags always land on a real device.
- `scopes.svelte.ts`: default `muted` to `false`. `volume` already defaults to `0`, which
  renders the distinct "no output" icon, so the two states stay visually different.

Both `isMuted` and `inputIsMuted` are changed for consistency.

## Notes

This may also be the underlying cause of #1590 ("nothing in the toolbox when I connect to my
bluetooth headset"): once no device is flagged as default, `defaultOutput` is `undefined` and
the media popup has nothing to render.

I could not build locally (no Rust toolchain on the machine where this was diagnosed), so the
Rust change is written against `master` and relies on CI for `cargo fmt`/`clippy`/`test`. The
analysis and the reproduction above are from a running 2.8.2 install.
