### PR TITLE
fix(apps-menu): show feedback while content initializes

### DIFF
--- a/src/ui/svelte/apps-menu/App.svelte
+++ b/src/ui/svelte/apps-menu/App.svelte
@@ -74,7 +74,9 @@
   });
 
   $effect(() => {
-    Widget.self.ready({ show: false });
+    if (!Widget.self.isReady) {
+      void Widget.self.ready({ show: false });
+    }
   });
 </script>
 

--- a/src/ui/svelte/apps-menu/index.ts
+++ b/src/ui/svelte/apps-menu/index.ts
@@ -1,25 +1,100 @@
+import { invoke, SeelenCommand, Widget } from "@seelen-ui/lib";
+import type { PhysicalMonitor, WidgetTriggerPayload } from "@seelen-ui/lib/types";
 import { getRootContainer } from "libs/ui/react/utils/index.ts";
 import { mount } from "svelte";
-import App from "./App.svelte";
-import { Widget } from "@seelen-ui/lib";
-import { onTriggered } from "./state/positioning.svelte.ts";
+import { StartDisplayMode } from "./constants";
+import { getAppsMenuRect, resolveTargetMonitor } from "./state/geometry";
 
 import "@seelen-ui/lib/styles/reset.css";
+import "./loading.css";
 
 const widget = Widget.getCurrent();
+const root = getRootContainer();
+
+const loadingShell = document.createElement("div");
+loadingShell.className = "apps-menu apps-menu-loading";
+loadingShell.dataset.fullscreen = "false";
+
+const loadingIndicator = document.createElement("div");
+loadingIndicator.className = "apps-menu-loading-indicator";
+loadingIndicator.setAttribute("aria-hidden", "true");
+loadingShell.append(loadingIndicator);
+root.append(loadingShell);
 
 await widget.init({ hideOnFocusLoss: true });
 await widget.window.setFocusable(true);
 
+type PositioningModule = typeof import("./state/positioning.svelte.ts");
+
+let positioningModule: PositioningModule | null = null;
+let contentLoadPromise: Promise<void> | null = null;
+let lastTrigger: WidgetTriggerPayload | null = null;
+
+async function readInitialDisplayMode(): Promise<StartDisplayMode> {
+  try {
+    const stored = JSON.parse(
+      await invoke(SeelenCommand.ReadFile, { filename: "display_mode.json" }),
+    );
+    return stored === StartDisplayMode.Fullscreen ? StartDisplayMode.Fullscreen : StartDisplayMode.Normal;
+  } catch {
+    return StartDisplayMode.Normal;
+  }
+}
+
+async function positionLoadingShell(args: WidgetTriggerPayload): Promise<void> {
+  const [monitors, displayMode] = await Promise.all([
+    invoke(SeelenCommand.SystemGetMonitors) as Promise<PhysicalMonitor[]>,
+    readInitialDisplayMode(),
+  ]);
+  const targetMonitor = resolveTargetMonitor(monitors, args.monitorId);
+  if (!targetMonitor) return;
+
+  loadingShell.dataset.fullscreen = String(displayMode === StartDisplayMode.Fullscreen);
+  await widget.setPosition(getAppsMenuRect(targetMonitor, displayMode));
+}
+
+function ensureContentLoaded(): Promise<void> {
+  if (contentLoadPromise) return contentLoadPromise;
+
+  contentLoadPromise = (async () => {
+    const [{ default: App }, positioning] = await Promise.all([
+      import("./App.svelte"),
+      import("./state/positioning.svelte.ts"),
+    ]);
+    positioningModule = positioning;
+
+    if (lastTrigger) {
+      await positioning.prepareForTrigger(lastTrigger.monitorId);
+    }
+
+    loadingShell.remove();
+    mount(App, { target: root });
+  })().catch((error) => {
+    contentLoadPromise = null;
+    console.error("Failed to load apps menu content", error);
+  });
+
+  return contentLoadPromise;
+}
+
 widget.onTrigger(async (args) => {
   const visible = await widget.window.isVisible();
   if (visible) {
-    widget.hide();
+    await widget.hide();
+  } else if (positioningModule) {
+    await positioningModule.onTriggered(args.monitorId);
   } else {
-    onTriggered(args.monitorId);
+    lastTrigger = args;
+    try {
+      await positionLoadingShell(args);
+    } catch (error) {
+      console.error("Failed to position apps menu loading shell", error);
+    }
+    await widget.show();
+    await widget.focus();
+    void ensureContentLoaded();
   }
 });
 
-mount(App, {
-  target: getRootContainer(),
-});
+await widget.ready({ show: false });
+void ensureContentLoaded();

--- a/src/ui/svelte/apps-menu/loading.css
+++ b/src/ui/svelte/apps-menu/loading.css
@@ -1,0 +1,23 @@
+.apps-menu.apps-menu-loading {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  place-items: center;
+  pointer-events: none;
+}
+
+.apps-menu-loading-indicator {
+  width: 28px;
+  height: 28px;
+  box-sizing: border-box;
+  border: 3px solid color-mix(in srgb, currentColor 20%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: apps-menu-loading-spin 700ms linear infinite;
+}
+
+@keyframes apps-menu-loading-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}

--- a/src/ui/svelte/apps-menu/state/geometry.ts
+++ b/src/ui/svelte/apps-menu/state/geometry.ts
@@ -1,0 +1,39 @@
+import type { PhysicalMonitor, Rect } from "@seelen-ui/lib/types";
+import { StartDisplayMode } from "../constants";
+
+export function resolveTargetMonitor(
+  monitors: PhysicalMonitor[],
+  monitorId?: string | null,
+): PhysicalMonitor | undefined {
+  return (
+    monitors.find((monitor) => monitor.id === monitorId) ||
+    monitors.find((monitor) => monitor.isPrimary) ||
+    monitors[0]
+  );
+}
+
+export function getAppsMenuRect(
+  targetMonitor: PhysicalMonitor,
+  displayMode: StartDisplayMode,
+): Rect {
+  const monitorWidth = targetMonitor.rect.right - targetMonitor.rect.left;
+  const monitorHeight = targetMonitor.rect.bottom - targetMonitor.rect.top;
+
+  if (displayMode === StartDisplayMode.Fullscreen) {
+    return { ...targetMonitor.rect };
+  }
+
+  const width = Math.round(Math.min(monitorWidth * 0.6, 1200 * targetMonitor.scaleFactor));
+  const height = Math.round(Math.min(monitorHeight * 0.6, 1200 * targetMonitor.scaleFactor));
+  const monitorCenterX = targetMonitor.rect.left + monitorWidth / 2;
+  const monitorCenterY = targetMonitor.rect.top + monitorHeight / 2;
+  const left = Math.round(monitorCenterX - width / 2);
+  const top = Math.round(monitorCenterY - height / 2);
+
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+  };
+}

--- a/src/ui/svelte/apps-menu/state/positioning.svelte.ts
+++ b/src/ui/svelte/apps-menu/state/positioning.svelte.ts
@@ -1,51 +1,15 @@
 import { Widget } from "@seelen-ui/lib";
 import type { PhysicalMonitor } from "@seelen-ui/lib/types";
 import { globalState } from "./mod.svelte";
-import { StartDisplayMode, StartView } from "../constants";
+import { StartView } from "../constants";
+import { getAppsMenuRect, resolveTargetMonitor } from "./geometry";
 
 let monitorToShow = $derived.by(() => {
-  let targetMonitor: PhysicalMonitor | undefined;
-
-  if (globalState.desiredMonitorId) {
-    targetMonitor = globalState.monitors.find((m) => m.id === globalState.desiredMonitorId);
-  }
-
-  // Fallback to primary monitor if not found or not specified
-  if (!targetMonitor) {
-    targetMonitor = globalState.monitors.find((m) => m.isPrimary) || globalState.monitors[0];
-  }
-
-  return targetMonitor;
+  return resolveTargetMonitor(globalState.monitors, globalState.desiredMonitorId);
 });
 
 async function placeCenteredToMonitor(targetMonitor: PhysicalMonitor): Promise<void> {
-  const widget = Widget.getCurrent();
-  const monitorWidth = targetMonitor.rect.right - targetMonitor.rect.left;
-  const monitorHeight = targetMonitor.rect.bottom - targetMonitor.rect.top;
-
-  // globalState.displayMode === StartDisplayMode.Fullscreen
-  let x = targetMonitor.rect.left;
-  let y = targetMonitor.rect.top;
-  let width = monitorWidth;
-  let height = monitorHeight;
-
-  if (globalState.displayMode === StartDisplayMode.Normal) {
-    width = Math.round(Math.min(monitorWidth * 0.6, 1200 * targetMonitor.scaleFactor));
-    height = Math.round(Math.min(monitorHeight * 0.6, 1200 * targetMonitor.scaleFactor));
-
-    const monitorCenterX = targetMonitor.rect.left + monitorWidth / 2;
-    const monitorCenterY = targetMonitor.rect.top + monitorHeight / 2;
-
-    x = Math.round(monitorCenterX - width / 2);
-    y = Math.round(monitorCenterY - height / 2);
-  }
-
-  await widget.setPosition({
-    left: x,
-    top: y,
-    right: x + width,
-    bottom: y + height,
-  });
+  await Widget.getCurrent().setPosition(getAppsMenuRect(targetMonitor, globalState.displayMode));
 }
 
 $effect.root(() => {
@@ -57,11 +21,18 @@ $effect.root(() => {
   });
 });
 
-export async function onTriggered(monitorId?: string | null) {
+export async function prepareForTrigger(monitorId?: string | null): Promise<void> {
   globalState.view = StartView.Favorites;
   globalState.desiredMonitorId = monitorId || null;
   globalState.version++; // trigger reactive updates
 
+  if (monitorToShow) {
+    await placeCenteredToMonitor(monitorToShow);
+  }
+}
+
+export async function onTriggered(monitorId?: string | null): Promise<void> {
+  await prepareForTrigger(monitorId);
   await Widget.self.show();
   await Widget.self.focus();
 }


### PR DESCRIPTION
## Summary

- initialize and mark the Apps Menu widget ready before its heavier application state finishes loading
- immediately start loading the full Apps Menu and application icons in the background during Seelen UI startup
- show a correctly positioned, theme-compatible shell and centered spinner only when the menu is triggered before that preload completes
- share monitor geometry between the loading shell and the fully loaded menu

## Problem

The Apps Menu entry point statically imports the full Svelte application. Its state module waits for settings, user data, monitors, Start Menu items, native pinned items, and persisted state before the entry point can register the trigger handler and mark the widget ready. On a cold start, clicking the Apps Menu during that interval can appear to do nothing.

The full menu is **not** intentionally deferred until first use. Preloading starts immediately after the lightweight widget shell is ready. In the normal case where preload finishes first, users still see the complete menu immediately; the loading shell is only visible for an early click during cold initialization.

This PR does not add or alter reversible visibility animations.

## Validation

- official pre-commit TypeScript, Svelte, Deno, formatting, and lint checks passed
- `svelte-check`: 0 errors and 0 warnings
- Deno checked 326 files successfully
- complete UI bundle: all 22 Svelte entry points built successfully
- repository pre-push Rust and JavaScript test hooks passed