### PR TITLE
feat(theme): add maximized adaptive toolbar

### DIFF
--- a/src/static/themes/maximized-adaptive-toolbar/i18n/description.yml
+++ b/src/static/themes/maximized-adaptive-toolbar/i18n/description.yml
@@ -1,0 +1,4 @@
+en: Adapts the Fancy Toolbar background to the gradient of the maximized window behind it.
+zh: 根据工具栏后方最大化窗口的渐变颜色调整 Fancy Toolbar 背景。
+zh-CN: 根据工具栏后方最大化窗口的渐变颜色调整 Fancy Toolbar 背景。
+zh-TW: 根據工具列後方最大化視窗的漸層色彩調整 Fancy Toolbar 背景。

--- a/src/static/themes/maximized-adaptive-toolbar/i18n/display_name.yml
+++ b/src/static/themes/maximized-adaptive-toolbar/i18n/display_name.yml
@@ -1,0 +1,4 @@
+en: Maximized Adaptive Toolbar
+zh: 最大化自适应工具栏
+zh-CN: 最大化自适应工具栏
+zh-TW: 最大化自適應工具列

--- a/src/static/themes/maximized-adaptive-toolbar/metadata.yml
+++ b/src/static/themes/maximized-adaptive-toolbar/metadata.yml
@@ -1,0 +1,13 @@
+id: "@wangjiancheng180/maximized-adaptive-toolbar"
+
+metadata:
+  displayName: !extend i18n/display_name.yml
+  description: !extend i18n/description.yml
+  tags:
+    - toolbar
+    - adaptive
+    - maximized
+  appTargetVersion: [2, 8, 3]
+
+styles:
+  "@seelen/fancy-toolbar": !include styles/toolbar.scss

--- a/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
+++ b/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
@@ -3,7 +3,6 @@
   isolation: isolate;
   box-sizing: border-box;
   border: 1px solid rgb(255 255 255 / 38%);
-  border-radius: 18px;
   color: rgb(255 255 255 / 96%);
   background: rgb(255 255 255 / 20%);
   box-shadow:
@@ -23,7 +22,6 @@
   inset: 0;
   pointer-events: none;
   content: "";
-  border-radius: inherit;
   z-index: 0;
   background: linear-gradient(
     135deg,

--- a/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
+++ b/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
@@ -1,8 +1,62 @@
+.ft-bar {
+  position: relative;
+  isolation: isolate;
+  box-sizing: border-box;
+  border: 1px solid rgb(255 255 255 / 38%);
+  border-radius: 18px;
+  color: rgb(255 255 255 / 96%);
+  background: rgb(255 255 255 / 20%);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 52%),
+    inset 0 -1px 0 rgb(255 255 255 / 14%),
+    0 6px 22px rgb(0 0 0 / 14%);
+  backdrop-filter: blur(16px) saturate(165%) brightness(1.08);
+  -webkit-backdrop-filter: blur(16px) saturate(165%) brightness(1.08);
+  transition:
+    background-color 0.22s ease,
+    border-color 0.22s ease,
+    box-shadow 0.22s ease;
+}
+
+.ft-bar::before {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  border-radius: inherit;
+  z-index: 0;
+  background: linear-gradient(
+    135deg,
+    rgb(255 255 255 / 24%),
+    transparent 42%,
+    rgb(255 255 255 / 7%)
+  );
+}
+
 .ft-bar[data-there-is-maximized-on-background="true"] {
   color: white;
   background: var(--window-gradient);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
-.ft-bar[data-there-is-maximized-on-background="true"] .ft-bar-item {
-  filter: drop-shadow(0 0 1px #000);
+.ft-bar[data-there-is-maximized-on-background="true"]::before {
+  display: none;
+}
+
+.ft-bar > *:not(.bg-layers) {
+  position: relative;
+  z-index: 1;
+}
+
+.ft-bar .ft-bar-item {
+  filter: drop-shadow(0 1px 1px rgb(0 0 0 / 42%));
+}
+
+.ft-bar .ft-bar-item-clickable:hover {
+  background: rgb(255 255 255 / 14%);
+}
+
+.ft-bar .ft-bar-item-clickable:active {
+  background: rgb(255 255 255 / 20%);
 }

--- a/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
+++ b/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
@@ -1,0 +1,8 @@
+.ft-bar[data-there-is-maximized-on-background="true"] {
+  color: white;
+  background: var(--window-gradient);
+}
+
+.ft-bar[data-there-is-maximized-on-background="true"] .ft-bar-item {
+  filter: drop-shadow(0 0 1px #000);
+}

--- a/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
+++ b/src/static/themes/maximized-adaptive-toolbar/styles/toolbar.scss
@@ -2,7 +2,6 @@
   position: relative;
   isolation: isolate;
   box-sizing: border-box;
-  border: 1px solid rgb(255 255 255 / 38%);
   color: rgb(255 255 255 / 96%);
   background: rgb(255 255 255 / 20%);
   box-shadow:


### PR DESCRIPTION
## Summary
- add a community theme for the Fancy Toolbar
- adapt the toolbar background to the gradient of the maximized window behind it
- improve item contrast with a subtle shadow
- include English and Chinese resource metadata

## Validation
- bundled successfully with slu resource bundle theme
- pre-push JavaScript and Rust checks passed